### PR TITLE
Bug fixes, flat-field corrections, and full mosaic pipeline (bin → stitch → vstitch → double-fov)

### DIFF
--- a/bin/tile
+++ b/bin/tile
@@ -19,6 +19,7 @@ from tile import config
 from tile import fileio
 from tile import shift
 from tile import stitch
+from tile import prep
 
 def init(args):
     if not os.path.exists(str(args.config)):
@@ -51,24 +52,44 @@ def run_stitch(args):
 def run_panoramic(args):
     shift.panoramic(args)
 
+def run_bin(args):
+    prep.bin_data(args)
+
+def run_dump_flats(args):
+    prep.dump_flats(args)
+
+def run_vstitch(args):
+    prep.vstitch(args)
+
+def run_double_fov(args):
+    prep.double_fov(args)
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', **config.SECTIONS['general']['config'])
-    show_params      = config.ALL_PARAMS
-    info_params      = config.INFO_PARAMS
-    center_params    = config.CENTER_PARAMS
-    shift_params     = config.SHIFT_PARAMS
-    stitch_params    = config.STITCH_PARAMS
-    panoramic_params = config.PANORAMIC_PARAMS
+    show_params       = config.ALL_PARAMS
+    info_params       = config.INFO_PARAMS
+    center_params     = config.CENTER_PARAMS
+    shift_params      = config.SHIFT_PARAMS
+    stitch_params     = config.STITCH_PARAMS
+    panoramic_params  = config.PANORAMIC_PARAMS
+    bin_params        = config.BIN_PARAMS
+    dump_flats_params = config.DUMP_FLATS_PARAMS
+    vstitch_params    = config.VSTITCH_PARAMS
+    double_fov_params = config.DOUBLE_FOV_PARAMS
 
     cmd_parsers = [
-        ('init',        init,            (),                  "Create configuration file"),
-        ('status',      status,          show_params,         "Show the tile-cli status"),
-        ('show',        run_show,        info_params,         "Show the file names in tile  location"),
-        ('center',      run_center,      center_params,       "Find the rotation axis location"),
-        ('shift',       run_shift,       shift_params,        "Calculate the tile horizonal shifts"),
-        ('panoramic',   run_panoramic,   panoramic_params,    "Save a single stitched projection for quick inspection"),
-        ('stitch',      run_stitch,      stitch_params,       "Create a single hdf file containing the tile datasets"),
+        ('init',        init,             (),                 "Create configuration file"),
+        ('status',      status,           show_params,        "Show the tile-cli status"),
+        ('show',        run_show,         info_params,        "Show the file names in tile location"),
+        ('bin',         run_bin,          bin_params,         "Spatially bin raw tile HDF5 files"),
+        ('dump-flats',  run_dump_flats,   dump_flats_params,  "Collect flat field basis from binned files"),
+        ('panoramic',   run_panoramic,    panoramic_params,   "Save a single stitched projection for quick inspection"),
+        ('center',      run_center,       center_params,      "Find the rotation axis location"),
+        ('shift',       run_shift,        shift_params,       "Calculate the tile horizontal shifts"),
+        ('stitch',      run_stitch,       stitch_params,      "Create a single hdf file containing the tile datasets"),
+        ('vstitch',     run_vstitch,      vstitch_params,     "Vertically stitch per-row tile.h5 files"),
+        ('double-fov',  run_double_fov,   double_fov_params,  "Convert 360° acquisition to 180° by stitching paired projections"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/bin/tile
+++ b/bin/tile
@@ -48,22 +48,27 @@ def run_shift(args):
 def run_stitch(args):
     stitch.stitching(args)
 
-def main():   
+def run_panoramic(args):
+    shift.panoramic(args)
+
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', **config.SECTIONS['general']['config'])
-    show_params     = config.ALL_PARAMS
-    info_params     = config.INFO_PARAMS
-    center_params   = config.CENTER_PARAMS
-    shift_params    = config.SHIFT_PARAMS
-    stitch_params   = config.STITCH_PARAMS
+    show_params      = config.ALL_PARAMS
+    info_params      = config.INFO_PARAMS
+    center_params    = config.CENTER_PARAMS
+    shift_params     = config.SHIFT_PARAMS
+    stitch_params    = config.STITCH_PARAMS
+    panoramic_params = config.PANORAMIC_PARAMS
 
     cmd_parsers = [
-        ('init',        init,           (),                 "Create configuration file"),
-        ('status',      status,         show_params,        "Show the tile-cli status"),
-        ('show',        run_show,       info_params,        "Show the file names in tile  location"),
-        ('center',      run_center,     center_params,      "Find the rotation axis location"),
-        ('shift',       run_shift,      shift_params,       "Calculate the tile horizonal shifts"),
-        ('stitch',      run_stitch,     stitch_params,      "Create a single hdf file containing the tile datasets"),
+        ('init',        init,            (),                  "Create configuration file"),
+        ('status',      status,          show_params,         "Show the tile-cli status"),
+        ('show',        run_show,        info_params,         "Show the file names in tile  location"),
+        ('center',      run_center,      center_params,       "Find the rotation axis location"),
+        ('shift',       run_shift,       shift_params,        "Calculate the tile horizonal shifts"),
+        ('panoramic',   run_panoramic,   panoramic_params,    "Save a single stitched projection for quick inspection"),
+        ('stitch',      run_stitch,      stitch_params,       "Create a single hdf file containing the tile datasets"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')
@@ -75,7 +80,11 @@ def main():
         cmd_parser.set_defaults(_func=func)
     
     args = config.parse_known_args(parser, subparser=True)
-    
+
+    if not hasattr(args, '_func'):
+        parser.print_help()
+        sys.exit(0)
+
     # create logger
     logs_home = args.logs_home
 

--- a/bin/tile
+++ b/bin/tile
@@ -35,8 +35,8 @@ def run_show(args):
     log.info('tile shift (x, y) in pixels: (%d, %d)' % (x_shift, y_shift))
     log.warning('tile overlap (x, y) in pixels: (%d, %d)' % (data_shape[2]-x_shift, data_shape[1]-y_shift))
 
-    index = [f'x_{num}' for num in range(grid.shape[0])]
-    columns = [f'y_{num}' for num in range(grid.shape[1])]
+    index = [f'y_{num}' for num in range(grid.shape[0])]
+    columns = [f'x_{num}' for num in range(grid.shape[1])]
     log.info('tile file name grid:\n%s' % pd.DataFrame(grid, columns=columns, index=index))
 
 def run_center(args):

--- a/bin/vstitch
+++ b/bin/vstitch
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+"""
+vstitch  –  Vertically stitch tile.h5 datasets.
+
+The input files are expected to already have flat/dark correction applied
+(data_white=1, data_dark=0), as produced by `tile stitch`.
+
+Example:
+    vstitch --pattern "../bin4x4/y*/tile/tile.h5" --y-shifts [0,450,450] --output vstitch.h5
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import h5py
+import numpy as np
+
+
+def _blend(n):
+    """Quintic blending ramp 0→1 of length n (same kernel as tile stitch)."""
+    v = np.linspace(0, 1, n, endpoint=False)
+    return v**5 * (126 - 420*v + 540*v**2 - 315*v**3 + 70*v**4)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Vertically stitch tile.h5 files.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--pattern', default='../bin4x4/y*/tile/tile.h5',
+                        help='Glob pattern for input files (sorted by name)')
+    parser.add_argument('--y-shifts', required=True,
+                        help='Relative y-shifts between consecutive tiles, e.g. [0,450,450]')
+    parser.add_argument('--output', default='vstitch.h5',
+                        help='Output HDF5 file')
+    parser.add_argument('--nproj-per-chunk', type=int, default=32,
+                        help='Projections processed per iteration')
+    args = parser.parse_args()
+
+    # parse y-shifts
+    y_shifts = np.fromstring(args.y_shifts[1:-1], sep=',', dtype='int')
+
+    # collect and sort input files
+    files = sorted(glob.glob(args.pattern))
+    if not files:
+        sys.exit(f'No files found matching: {args.pattern}')
+    if len(files) != len(y_shifts):
+        sys.exit(f'{len(files)} files found but {len(y_shifts)} y-shifts given')
+
+    print(f'Found {len(files)} file(s):')
+    for f, ys in zip(files, y_shifts):
+        print(f'  y_shift={ys:4d}  {f}')
+
+    # geometry from first file
+    with h5py.File(files[0], 'r') as f0:
+        N_proj, H, W = f0['/exchange/data'].shape
+        theta = f0['/exchange/theta'][:]
+
+    # cumulative row positions: tile i starts at row cum[i]
+    cum = np.array([int(np.sum(y_shifts[:i+1])) for i in range(len(y_shifts))])
+    H_out = H + int(cum[-1])
+
+    print(f'Input  shape: {N_proj} x {H} x {W}')
+    print(f'Output shape: {N_proj} x {H_out} x {W}')
+    print(f'Output file : {args.output}')
+
+    if os.path.exists(args.output):
+        os.remove(args.output)
+
+    with h5py.File(args.output, 'w') as fout:
+        data_out = fout.create_dataset(
+            '/exchange/data', shape=(N_proj, H_out, W), dtype='float32',
+            chunks=(1, H_out, W))
+        fout.create_dataset('/exchange/data_white',
+                            data=np.ones((1, H_out, W), dtype='float32'))
+        fout.create_dataset('/exchange/data_dark',
+                            data=np.zeros((1, H_out, W), dtype='float32'))
+        fout.create_dataset('/exchange/theta', data=theta)
+
+        for st_p in range(0, N_proj, args.nproj_per_chunk):
+            end_p = min(st_p + args.nproj_per_chunk, N_proj)
+            n = end_p - st_p
+            print(f'  projections {st_p:4d} – {end_p:4d}', end='\r', flush=True)
+
+            buf = np.zeros((n, H_out, W), dtype='float32')
+
+            for itile, (fpath, row_st) in enumerate(zip(files, cum)):
+                row_end = row_st + H
+
+                # blending weights along the vertical axis
+                ww = np.ones(H, dtype='float32')
+                if itile < len(files) - 1:
+                    overlap_bot = H - y_shifts[itile + 1]
+                    if overlap_bot > 0:
+                        v = np.linspace(1, 0, overlap_bot, endpoint=False)
+                        v = v**5 * (126 - 420*v + 540*v**2 - 315*v**3 + 70*v**4)
+                        ww[y_shifts[itile + 1]:] = v
+                if itile > 0:
+                    overlap_top = H - y_shifts[itile]
+                    if overlap_top > 0:
+                        v = np.linspace(1, 0, overlap_top, endpoint=False)
+                        v = v**5 * (126 - 420*v + 540*v**2 - 315*v**3 + 70*v**4)
+                        ww[:overlap_top] = 1 - v
+
+                with h5py.File(fpath, 'r') as fin:
+                    chunk = fin['/exchange/data'][st_p:end_p].astype('float32')
+
+                buf[:, row_st:row_end, :] += chunk * ww[np.newaxis, :, np.newaxis]
+
+            np.nan_to_num(buf, nan=0.0, posinf=0.0, neginf=0.0, copy=False)
+            data_out[st_p:end_p] = buf
+
+    print(f'\nDone. Output: {args.output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -55,7 +55,7 @@ and `32 ID <https://docs32id.readthedocs.io/en/latest/>`_.
 Once the above are confirmed, you can validate the mosaic data set with:
 ::
 
-    (tile)$ tile show --folder-name /data/2021-12/Duchkov/mosaic/
+    (tomocupy) tomo@tomo4 $ tile show --folder-name /data/2021-12/Duchkov/mosaic/
     2022-02-16 11:33:38,485 - Started tile
     2022-02-16 11:33:38,485 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_11_33_38.log
     2022-02-16 11:33:38,485 - checking tile files ...
@@ -73,35 +73,64 @@ Once the above are confirmed, you can validate the mosaic data set with:
                                                  y_0                                          y_1                                          y_2                                          y_3                                          y_4
     x_0  /data/2021-12/Duchkov/mosaic/mosaic_2073.h5  /data/2021-12/Duchkov/mosaic/mosaic_2074.h5  /data/2021-12/Duchkov/mosaic/mosaic_2075.h5  /data/2021-12/Duchkov/mosaic/mosaic_2076.h5  /data/2021-12/Duchkov/mosaic/mosaic_2077.h5
 
-2. Find rotation center
-=======================
+2. Quick panoramic inspection (optional)
+=========================================
 
-The first step is to find the location of the rotation axis of the stitched data set. The command below, **tile center**, will stitch the projections horizontally using, as first approximation, the nominal overlap distance stored in the hdf file and will then generate a stack of reconstructed images containing the same slice (default slice is vertically in the center, adjustable with --nsino) with location of the rotation axis +/- 50 pixel around the middle of the horizontal size of the detector with steps of 0.25 pixels. The stack of reconstructed slice will be done using tomocupy.
+Before running the time-consuming center search, use **tile panoramic** to quickly verify the tile layout and get a visual impression of the nominal overlap quality. It reads a single projection (at the angle set by ``--nprojection``, default 0.5 = midpoint) from each tile, normalizes it, and saves a wide stitched image to ``tile/panoramic.tif``:
 
 ::
 
-    (tile)$ tile center --nproj-per-chunk 64 --folder-name /data/2021-12/Duchkov/mosaic/ --nsino-per-chunk 2 --binning 2 --center-search-width 50 --center-search-step 0.25 --recon-engine tomocupy
-    2022-02-16 15:29:38,906 - Started tile
-    2022-02-16 15:29:38,906 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_15_29_38.log
-    2022-02-16 15:29:38,906 - Run find rotation axis location
-    2022-02-16 15:29:38,906 - checking tile files ...
-    2022-02-16 15:29:38,906 - Checking directory: /data/2021-12/Duchkov/mosaic for a tile scan
-    2022-02-16 15:29:39,286 - tile file sorted
-    2022-02-16 15:29:39,287 - x0y0: x = -0.000100; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2073.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2073.h5
-    2022-02-16 15:29:39,287 - x1y0: x = 0.849900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2074.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2074.h5
-    2022-02-16 15:29:39,287 - x2y0: x = 1.699900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2075.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2075.h5
-    2022-02-16 15:29:39,287 - x3y0: x = 2.549900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2076.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2076.h5
-    2022-02-16 15:29:39,287 - x4y0: x = 3.399900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2077.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2077.h5
-    2022-02-16 15:29:39,456 - image   size (x, y) in pixels: (2448, 2048)
-    2022-02-16 15:29:39,456 - stitch shift (x, y) in pixels: (2428, 0)
-    2022-02-16 15:29:39,456 - tile overlap (x, y) in pixels: (20, 2048)
-    2022-02-16 15:29:42,657 - Created a temporary hdf file: /data/2021-12/Duchkov/mosaic/tile/tmp.h5
-    2022-02-16 15:29:42,658 - Running: tomocupy recon --file-type double_fov --binning 2 --reconstruction-type try --file-name /data/2021-12/Duchkov/mosaic/tile/tmp.h5 --center-search-width 50.0 --rotation-axis-auto manual --rotation-axis 1224.0   --center-search-step 0.25
-    2022-02-16 15:29:44,427 - Try rotation center reconstruction for slice 0
-    queue size 000 |  |████████████████████████████████████████| 100.0% 
-    2022-02-16 15:30:00,651 - Output: /data/2021-12/Duchkov/mosaic/tile_recgpu/try_center/tmp/r_
-    Reconstruction time 23.8s
-    2022-02-16 15:30:08,307 - Please open the stack of images from /data/2021-12/Duchkov/mosaic/tile_recgpu/try_center/tmp/recon* and select the rotation center
+    (tomocupy) tomo@tomo4 $ tile panoramic --flat-linear True
+
+Open the result in `Fiji ImageJ <https://imagej.net/software/fiji/>`_ to confirm:
+
+- All tiles are present and in the correct order.
+- The nominal overlap looks approximately correct (the seam regions may not be perfect yet — that is fine and expected).
+- The sample fills the expected field of view.
+
+Once you have determined the correct shifts (after running **tile shift**), you can regenerate the panoramic with the corrected positions:
+
+::
+
+    (tomocupy) tomo@tomo4 $ tile panoramic --flat-linear True --x-shifts "[0, 5430, 5419]"
+
+3. Find rotation center
+=======================
+
+**tile center** finds the rotation axis location of the stitched dataset. It stitches all horizontal tiles in the **top row** (y0) of the tile grid using the nominal overlap distance stored in the hdf file, then reconstructs a stack of trial slices over a search range around the specified rotation axis. The vertical sinogram row used is controlled by ``--nsino`` (default 0.5 = vertical center of the detector; adjustable from 0 top to 1 bottom). With ``--binning N``, ``2**N`` consecutive sinogram rows are averaged. The reconstruction is performed with the engine specified by ``--recon-engine`` (tomocupy or tomopy).
+
+.. warning::
+
+   The default value of ``--reverse-grid`` (True) assumes that moving the sample stage in the positive X direction moves the sample to the **left** in the image (as seen by the detector). This is the case at 2-BM after the detector upgrade. If you are using an older setup where positive X moves the sample to the **right**, pass ``--reverse-grid False`` explicitly.
+
+   The default value of ``--file-type`` is ``double_fov``, which is the standard mode at 2-BM. Pass ``--file-type standard`` for single field-of-view datasets.
+
+Use ``--flat-linear True`` when flat fields were collected at the beginning and end of the scan (e.g. 20+20): the first and second halves are averaged separately and linearly interpolated across all projection angles for more accurate normalization.
+
+.. note::
+
+   At this stage only the **center of the reconstructed image** is reliable. The outer regions (left and right "donuts") may look blurry because the nominal tile overlap from the hdf file is only approximate. Ignore the outer regions and focus on the center when selecting the rotation axis.
+
+The recommended workflow is **two passes**: a coarse search to locate the approximate center, followed by a fine search to pin it down to sub-pixel accuracy.
+
+**Pass 1 — coarse search** (wide step, large range):
+
+::
+
+    (tomocupy) tomo@tomo4 ~/conda/tile-decarlof $ tile center --recon-engine tomocupy --rotation-axis 400 --file-type double_fov --binning 2 --nsino-per-chunk 2 --flat-linear True
+    2026-03-24 15:18:38,306 - Started tile
+    2026-03-24 15:18:38,306 - Saving log at /home/beams/TOMO/logs/tile_2026-03-24_15_18_38.log
+    2026-03-24 15:18:38,306 - Run find rotation axis location
+    ...
+    2026-03-24 15:18:41,679 - image   size (x, y) in pixels: (6464, 4852)
+    2026-03-24 15:18:41,679 - stitch shift (x, y) in pixels: (5416, 4561)
+    2026-03-24 15:18:41,679 - tile overlap (x, y) in pixels: (1048, 291)
+    2026-03-24 15:18:48,953 - Created a temporary hdf file: /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5
+    2026-03-24 15:18:48,954 - tomocupy recon --file-type double_fov --binning 2 --reconstruction-type try --file-name /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5             --center-search-width 10.0 --rotation-axis-auto manual --rotation-axis 400.0             --center-search-step 0.5 --end-column -1 --nsino-per-chunk 2 --flat-linear True
+    2026-03-24 15:19:55,427 - Processing slice 0
+    queue size 000 |  |████████████████████████████████████████| 100.0%
+    2026-03-24 15:20:00,821 - Reconstruction time 1.2e+01s
+    2026-03-24 15:20:05,333 - Please open the stack of images from /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile_rec/try_center/tmp/recon* and select the rotation center
 
 Use `Fiji ImageJ <https://imagej.net/software/fiji/>`_  to load the reconstructed slice stack with File/Import/Image Sequence:
 
@@ -110,7 +139,7 @@ Use `Fiji ImageJ <https://imagej.net/software/fiji/>`_  to load the reconstructe
    :alt: project
 
 
-Zoom into the center region of the image and move the slider: 
+Zoom into the center region of the image and move the slider:
 
 .. image:: img/tile_center_01.png
    :width: 720px
@@ -123,39 +152,66 @@ until the center of the image is sharp and free of artifacts:
    :width: 720px
    :alt: project
 
-Please focus only on the center of the image for now. Once done, on the top left corner of the image you will see the corresponding rotation axis location, 1246 in this case. Store this for the next step.
+Note the rotation axis value shown in the top-left corner of the best image (656 in this example). Then re-run with a finer step centered on that value.
 
-3. Tile Shift
-=============
-
-**tile center** used the nominal tile overlap distance stored in the hdf file. In this step, **tile shift** will fine tune each tile location. This process will keep the center tile fixed and slide one at the time each of the tiles moving away from the center tile.
-
-The optimal tile locations will be determined looking at reconstructed slices or at projections generated by sliding the overlap region along a preset --shift-search-width in steps of --shift-search-step pixels. The command below will shift the tiles, one at the time, by +/- 30 pixel from the nominal location stored in the hdf file at data collection time, in step of 2 pixels.
+**Pass 2 — fine search** (small step, narrow range):
 
 ::
 
-    (tile)$ tile shift --folder-name /data/2021-12/Duchkov/mosaic/ --shift-search-width 30 --shift-search-step 2 --recon-engine tomocupy
-    2022-02-16 17:30:08,246 - Started tile
-    2022-02-16 17:30:08,247 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_17_30_08.log
-    2022-02-16 17:30:08,247 - Run manual shift
-    2022-02-16 17:30:08,247 - checking tile files ...
-    2022-02-16 17:30:08,247 - Checking directory: /data/2021-12/Duchkov/mosaic for a tile scan
-    2022-02-16 17:30:08,626 - tile file sorted
-    2022-02-16 17:30:08,626 - x0y0: x = -0.000100; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2073.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2073.h5
-    2022-02-16 17:30:08,626 - x1y0: x = 0.849900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2074.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2074.h5
-    2022-02-16 17:30:08,626 - x2y0: x = 1.699900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2075.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2075.h5
-    2022-02-16 17:30:08,626 - x3y0: x = 2.549900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2076.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2076.h5
-    2022-02-16 17:30:08,626 - x4y0: x = 3.399900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2077.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2077.h5
-    2022-02-16 17:30:08,792 - image   size (x, y) in pixels: (2448, 2048)
-    2022-02-16 17:30:08,792 - stitch shift (x, y) in pixels: (2428, 0)
-    2022-02-16 17:30:08,792 - tile overlap (x, y) in pixels: (20, 2048)
-    Please enter rotation center (1224.0): 1246
-    2022-02-16 17:32:09,507 - Full reconstruction
-    queue size 000 |  |████████████████████████████████████████| 100.0% 
-    2022-02-16 17:32:31,184 - Output: /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/r
-    Reconstruction time 26.3s
-    Please open the stack of images from reconstructions /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/recon* or stitched projections /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_proj/p*, and select the file id to shift tile 1
-    Please enter id for tile 1: 
+    (tomocupy) tomo@tomo4 ~/conda/tile-decarlof $ tile center --recon-engine tomocupy --rotation-axis 656 --file-type double_fov --binning 2 --nsino-per-chunk 2 --flat-linear True --center-search-width 10 --center-search-step 1
+    2026-03-24 16:42:14,152 - Started tile
+    2026-03-24 16:42:14,152 - Saving log at /home/beams/TOMO/logs/tile_2026-03-24_16_42_14.log
+    2026-03-24 16:42:14,152 - Run find rotation axis location
+    ...
+    2026-03-24 16:42:17,524 - image   size (x, y) in pixels: (6464, 4852)
+    2026-03-24 16:42:17,525 - stitch shift (x, y) in pixels: (5416, 4561)
+    2026-03-24 16:42:17,525 - tile overlap (x, y) in pixels: (1048, 291)
+    2026-03-24 16:42:25,225 - Created a temporary hdf file: /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5
+    2026-03-24 16:42:25,226 - tomocupy recon --file-type double_fov --binning 2 --reconstruction-type try --file-name /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5             --center-search-width 10.0 --rotation-axis-auto manual --rotation-axis 656.0             --center-search-step 1.0 --end-column -1 --nsino-per-chunk 2 --flat-linear True
+    2026-03-24 16:43:31,516 - Processing slice 0
+    queue size 000 |  |████████████████████████████████████████| 100.0%
+    2026-03-24 16:43:36,281 - Reconstruction time 1.1e+01s
+    2026-03-24 16:43:40,757 - Please open the stack of images from /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile_rec/try_center/tmp/recon* and select the rotation center
+
+Inspect the stack again and record the final rotation axis (650 in this example). Store this for the next step.
+
+4. Tile Shift
+=============
+
+**tile center** used the nominal tile overlap distance stored in the hdf file. In this step, **tile shift** fine-tunes each tile's horizontal position. It operates on the **top row (y0)** of the tile grid, using the same sinogram row as ``tile center`` (controlled by ``--nsino``).
+
+For each tile boundary (there are N-1 boundaries for N horizontal tiles), the tool reconstructs a stack of slices by sliding the overlap of the adjacent tile by ``--shift-search-width`` pixels in steps of ``--shift-search-step`` pixels on either side of the nominal position. The total number of shifts tried per boundary is ``2 * shift_search_width / shift_search_step`` (default: 40 shifts per boundary with ``--shift-search-width 20 --shift-search-step 1``).
+
+A progress bar is displayed during processing and, when complete, a color-coded index map is printed:
+
+- **green** indices correspond to negative offsets (tiles closer together than nominal)
+- **red** index corresponds to 0 px offset (perfect motor motion = nominal overlap)
+- **yellow** indices correspond to positive offsets (tiles farther apart than nominal)
+
+The user is then prompted to enter the index of the best-looking frame from the reconstructed stack (or stitched projections), repeating for each tile boundary. The prompt shows the **nominal index** (the one corresponding to 0 px correction), which is the correct answer if motor positioning was perfect.
+
+::
+
+    (tomocupy) tomo@tomo4 ~/conda/tile-decarlof $ tile shift --flat-linear True --rotation-axis 650
+    2026-03-25 15:29:12,127 - Started tile
+    2026-03-25 15:29:12,128 - Saving log at /home/beams/TOMO/logs/tile_2026-03-25_15_29_12.log
+    2026-03-25 15:29:12,128 - Run manual shift
+    2026-03-25 15:29:12,128 - checking tile files ...
+    2026-03-25 15:29:12,128 - Checking directory: /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data for a tile scan
+    2026-03-25 15:29:14,421 - tile file sorted
+    2026-03-25 15:29:14,422 - x0y0: x = 0.900000; y = -3.000000, file name = .../coffe_beam_mosaic_001.h5
+    2026-03-25 15:29:14,422 - x1y0: x = 2.800000; y = -3.000000, file name = .../coffe_beam_mosaic_002.h5
+    2026-03-25 15:29:14,422 - x2y0: x = 4.700000; y = -3.000000, file name = .../coffe_beam_mosaic_003.h5
+    ...
+    2026-03-25 15:29:15,577 - image   size (x, y) in pixels: (6464, 4852)
+    2026-03-25 15:29:15,577 - stitch shift (x, y) in pixels: (5416, 4561)
+    2026-03-25 15:29:15,577 - tile overlap (x, y) in pixels: (1048, 291)
+    Please enter rotation center (656.2): 650
+    2026-03-25 15:29:16,100 - Processing tile boundary 1 of 2
+      [████████████████████████████████████████] 80/80 (+39 px)
+    Index-to-pixel-offset map for tile 1: 0=-40px, 1=-39px, ... 40=+0px, ... 79=+39px
+    2026-03-25 15:47:00,123 - Please open the stack of images from reconstructions .../tile_rec/tmp_rec/recon* or stitched projections .../tile_rec/tmp_proj/p*, and select the file id to shift tile 1
+    Please enter id for tile 1 shift [nominal: 40] corresponding to 0 pixel shift from the nominal overlap of 1048 px stored in the raw data files:
 
 Use `Fiji ImageJ <https://imagej.net/software/fiji/>`_  to load the reconstructed slice or projection stack with File/Import/Image Sequence:
 
@@ -164,69 +220,51 @@ Use `Fiji ImageJ <https://imagej.net/software/fiji/>`_  to load the reconstructe
    :alt: project
 
 
-Zoom into the region of the image separating the center tile from the first tile and move the slider: 
+Zoom into the region of the image separating the two tiles and move the slider:
 
 .. image:: img/tile_shift_01.png
    :width: 720px
    :alt: project
 
 
-until the image in the second tile is sharp and free of artifacts:
+until the boundary region between the two tiles is sharp and free of artifacts:
 
 .. image:: img/tile_shift_02.png
    :width: 720px
    :alt: project
 
-On the top left corner of the image you will see the corresponding tile overlap index, 26 in this case, and enter it at:
+The file name in Fiji's title bar (e.g. ``recon_00054.tif``) tells you the index to enter. In the example above that is index 54, which maps to +14 px from the index-to-pixel-offset map — meaning the stage was 14 pixels (≈ 9 µm at 0.65 µm/px resolution) further apart than the motor position stored in the hdf file.
+
+Pressing **Enter** without typing anything accepts the nominal index (0 px correction).
 
 ::
 
-    Please enter id for tile 1: 26
-    2022-02-16 18:14:22,816 - Current shifts: [   0 2450 2428 2428 2428]
+    Please enter id for tile 1 shift [nominal: 40] ...: 54
+    2026-03-25 15:47:02,348 - Selected offset for tile 1: +14 px from nominal (index 54)
+    2026-03-25 15:47:02,349 - Current shifts: [   0 5430 5416]
 
-**tile shift** will now repeat the same keeping the center tile and first tile fixed and slide the next tile only.
-
-::
-
-    Please enter id for tile 1: 26
-    2022-02-16 18:14:22,816 - Current shifts: [   0 2450 2428 2428 2428]
-    2022-02-16 18:16:02,917 - Full reconstruction
-    queue size 000 |  |████████████████████████████████████████| 100.0% 
-    2022-02-16 18:16:26,167 - Output: /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/r
-    Reconstruction time 28.1s
-    Please open the stack of images from reconstructions /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/recon* or stitched projections /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_proj/p*, and select the file id to shift tile 2
-
-Repeat the `Fiji ImageJ <https://imagej.net/software/fiji/>`_ image inspection looking at the next set of tile overlap region, and, as before, enter the corresponding tile overlap index and move to the next tile.
+**tile shift** will now repeat the same process, keeping all previously fixed tiles fixed and sliding the next tile boundary only.
 
 ::
 
-    Please enter id for tile 2: 26
-    2022-02-16 18:20:36,145 - Current shifts: [   0 2450 2450 2428 2428]
-    2022-02-16 18:22:16,112 - Full reconstruction
-    queue size 000 |  |████████████████████████████████████████| 100.0% 
-    2022-02-16 18:22:38,549 - Output: /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/r
-    Reconstruction time 27.1s
-    Please open the stack of images from reconstructions /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/recon* or stitched projections /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_proj/p*, and select the file id to shift tile 3
-    Please enter id for tile 3: 27
-    2022-02-16 18:23:27,249 - Current shifts: [   0 2450 2450 2452 2428]
-    2022-02-16 18:25:07,526 - Full reconstruction
-    queue size 000 |  |████████████████████████████████████████| 100.0% 
-    2022-02-16 18:25:29,959 - Output: /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/r
-    Reconstruction time 27.3s
-    Please open the stack of images from reconstructions /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_rec/recon* or stitched projections /data/2021-12/Duchkov/mosaic/tile_recgpu/tmp_proj/p*, and select the file id to shift tile 4
-    Please enter id for tile 4: 28
-    2022-02-16 18:25:53,832 - Current shifts: [   0 2450 2450 2452 2454]
-    2022-02-16 18:25:53,833 - Center 1246
-    2022-02-16 18:25:53,833 - Relative shifts [0, 2450, 2450, 2452, 2454]
+    2026-03-25 15:47:02,350 - Processing tile boundary 2 of 2
+      [████████████████████████████████████████] 80/80 (+39 px)
+    Index-to-pixel-offset map for tile 2: 0=-40px, 1=-39px, ... 40=+0px, ... 79=+39px
+    2026-03-25 16:02:14,511 - Please open the stack of images from reconstructions .../tile_rec/tmp_rec/recon* ...
+    Please enter id for tile 2 shift [nominal: 40] corresponding to 0 pixel shift from the nominal overlap of 1048 px stored in the raw data files: 43
+    2026-03-25 16:02:20,812 - Selected offset for tile 2: +3 px from nominal (index 43)
+    2026-03-25 16:02:20,813 - Current shifts: [   0 5430 5419]
+    2026-03-25 16:02:20,814 - Center 650
+    2026-03-25 16:02:20,815 - Relative shifts [0, 5430, 5419]
 
-4. Tile Stitch 
+5. Tile Stitch
 ==============
 
-At the end of **tile shift** step, we obtain a list of shifts [0, 2450, 2450, 2452, 2454] that we can use for the final tile stiching. **tile stitch** will generate a single hdf file merging all mosaic tiles with the correct overlap.
+At the end of **tile shift** step, we obtain the final shift list (e.g. ``[0, 5430, 5419]``) that we can use for the final tile stitching. **tile stitch** will generate a single hdf file merging all mosaic tiles with the correct overlap.
 
 ::
 
-    (tile)$ tile stitch --folder-name /data/2021-12/Duchkov/mosaic --nproj-per-chunk 128 --x-shifts "[0, 2450, 2450, 2452, 2454]" 
+    (tomocupy) tomo@tomo4 $ tile stitch --folder-name /data/2021-12/Duchkov/mosaic --nproj-per-chunk 128 --x-shifts "[0, 2450, 2450, 2452, 2454]" 
     2022-02-16 18:30:06,770 - Started tile
     2022-02-16 18:30:06,770 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_18_30_06.log
     2022-02-16 18:30:06,770 - Run stitching
@@ -292,7 +330,7 @@ At the end of **tile shift** step, we obtain a list of shifts [0, 2450, 2450, 24
     2022-02-16 19:03:41,110 - Reconstruct /data/2021-12/Duchkov/mosaic/tile/tile.h5 with tomopy:
     2022-02-16 19:03:41,110 - tomopy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
 
-5. Tile reconstruction 
+6. Tile reconstruction
 ======================
 
 Once the stitching is completed the tomographic reconstruction can be done with `tomocupy <https://tomocupy.readthedocs.io/en/latest/>`_ or `tomopy <https://tomopy.readthedocs.io/en/latest/>`_/`tomopycli <https://tomopycli.readthedocs.io/en/latest/>`_:
@@ -300,16 +338,161 @@ Once the stitching is completed the tomographic reconstruction can be done with 
 with **tomocupy**
 ::
  
-    (tile)$ tomocupy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
+    (tomocupy) tomo@tomo4 $ tomocupy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
 
 with **tomopy**
 ::
  
-    (tile)$ tomopy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
+    (tomocupy) tomo@tomo4 $ tomopy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
 
 For more options:
 ::
 
-    (tile)$ tile -h
-    (tile)$ tile stitch -h
-    (tile)$ tile shift -h 
+    (tomocupy) tomo@tomo4 $ tile -h
+    (tomocupy) tomo@tomo4 $ tile stitch -h
+    (tomocupy) tomo@tomo4 $ tile shift -h
+
+
+Quick Start Guide
+=================
+
+This section summarizes the full mosaic reconstruction workflow in plain language for new users.
+
+**What you have:** a set of hdf5 files, each containing a tomographic scan of one tile of the sample. The tiles overlap slightly and together cover a field of view larger than a single scan.
+
+**What you want:** a single reconstructed 3D volume of the full sample.
+
+The process has six steps (step 2 is optional):
+
+----
+
+Step 1 — Verify the dataset (``tile show``)
+--------------------------------------------
+
+**What it does:**
+
+Reads the hdf metadata from all tile files, sorts them by motor position, and prints the tile grid layout, image size, and nominal overlap. Use this to confirm all tiles are present and correctly ordered before doing anything else.
+
+::
+
+    (tomocupy) tomo@tomo4 $ tile show --folder-name /path/to/data
+
+----
+
+Step 2 — Quick panoramic inspection (optional, ``tile panoramic``)
+------------------------------------------------------------------
+
+**What it does:**
+
+Reads a single projection from each tile, normalizes it, and saves a wide stitched image to ``tile/panoramic.tif`` using the nominal overlap from the hdf file (or ``--x-shifts`` if provided). Open the result in Fiji to visually confirm the tile layout and get a sense of the overlap quality before running the longer center search.
+
+::
+
+    (tomocupy) tomo@tomo4 $ tile panoramic --flat-linear True
+
+----
+
+Step 3 — Find the rotation center (``tile center``)
+----------------------------------------------------
+
+**What it does:**
+
+Takes all horizontal tiles from the top row of the mosaic, stitches them side by side using the nominal overlap stored in the hdf file, and reconstructs a stack of trial images — each one using a slightly different rotation axis position. You inspect the stack and pick the sharpest image.
+
+.. note::
+
+   Only the **center of the reconstructed image** is reliable at this stage. The outer regions (left and right "donuts") may look blurry because the nominal tile overlap from the hdf file is only approximate. Ignore the outer regions for now and focus on the center.
+
+**How to run (two passes recommended):**
+
+*Pass 1 — coarse:* start with a large search range to find the approximate center::
+
+    (tomocupy) tomo@tomo4 $ tile center --recon-engine tomocupy --file-type double_fov \
+        --binning 2 --nsino-per-chunk 2 --flat-linear True \
+        --rotation-axis 400 --center-search-width 100 --center-search-step 5
+
+Open the output stack in Fiji (File → Import → Image Sequence), zoom into the **center of the image**, and move the slider until the center region is sharp. Note the rotation axis value shown in the top-left corner of the best image (e.g. 656).
+
+*Pass 2 — fine:* narrow the search around the value you found::
+
+    (tomocupy) tomo@tomo4 $ tile center --recon-engine tomocupy --file-type double_fov \
+        --binning 2 --nsino-per-chunk 2 --flat-linear True \
+        --rotation-axis 656 --center-search-width 5 --center-search-step 0.1
+
+Repeat the Fiji inspection and record the final value (e.g. **656.2**). This is your rotation center.
+
+----
+
+Step 4 — Fine-tune the tile overlap positions (``tile shift``)
+---------------------------------------------------------------
+
+**What it does:**
+
+The nominal overlap from the hdf file is only approximate (limited by stage positioning accuracy, typically a few micrometers). This step fine-tunes the horizontal position of each tile relative to its neighbor so that the full stitched image — including the outer "donut" regions — is sharp.
+
+It works tile by tile, left to right. For each tile boundary it tries sliding the adjacent tile by ±20 pixels (adjustable) from the nominal position and reconstructs a stack for you to inspect. You pick the frame where the **boundary region between the two tiles** looks sharpest and seamless.
+
+**How to run:**
+
+::
+
+    (tomocupy) tomo@tomo4 $ tile shift --flat-linear True --rotation-axis 656.2
+
+When prompted, confirm or update the rotation center. For each tile boundary the tool:
+
+1. Runs the reconstruction for all candidate shifts (progress bar displayed).
+2. Prints a color-coded index map: **green** = negative offset, **red** = nominal (0 px), **yellow** = positive offset.
+3. Asks you to enter an index.
+
+Then:
+
+1. Open the reconstruction stack ``tile_rec/tmp_rec/recon*`` **or** the projection stack ``tile_rec/tmp_proj/p*`` in Fiji.
+2. Zoom into the **overlap region between the two tiles** (not the center of the image).
+3. Move the slider until the boundary is sharp and artifact-free.
+4. Read the index from the file name shown by Fiji (e.g. ``recon_00054.tif`` → index 54) and enter it at the prompt.
+
+.. note::
+
+   The prompt shows ``[nominal: 40]`` (or whichever index corresponds to 0 px offset). Pressing **Enter** without typing accepts the nominal, which is correct when stage positioning is perfect. A selection of 54 where nominal is 40 means the stage was +14 px (≈ 9 µm at 0.65 µm/px) farther apart than the hdf file recorded.
+
+Repeat for each tile boundary. At the end the tool prints the final shift array, e.g.::
+
+    Current shifts: [0, 5430, 5419]
+
+Save this for the next step.
+
+----
+
+Step 5 — Stitch all tiles into a single file (``tile stitch``)
+---------------------------------------------------------------
+
+**What it does:**
+
+Uses the corrected overlap positions from Step 2 to merge all mosaic tiles (all rows, all projections) into a single hdf5 file ready for reconstruction.
+
+**How to run:**
+
+::
+
+    (tomocupy) tomo@tomo4 $ tile stitch --x-shifts "[0, 5418, 5420]" --nproj-per-chunk 128
+
+The output file is written to ``tile/tile.h5`` inside your data folder.
+
+----
+
+Step 6 — Reconstruct (``tomocupy`` or ``tomopy``)
+--------------------------------------------------
+
+**What it does:**
+
+Runs the full tomographic reconstruction on the stitched file.
+
+**How to run:**
+
+::
+
+    (tomocupy) tomo@tomo4 $ tomocupy recon --file-name /path/to/tile/tile.h5 \
+        --rotation-axis 656.2 --reconstruction-type full \
+        --file-type double_fov --flat-linear True \
+        --remove-stripe-method fw --binning 0 \
+        --nsino-per-chunk 4 --rotation-axis-auto manual

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,498 +1,641 @@
 =====
 Usage
 =====
- 
-1. Verify the dataset is valid
-==============================
 
-Tile needs the following experiment meta data to automatically sort the mosaic tiles by location and set the initial overlapping conditions:
+Overview
+========
 
-#. X-Y location of each tile in mm
-#. the projection image pixel size in microns
-#. the tile data set full file name
+**tile** is a command-line tool for stitching tomographic mosaic datasets — sets of overlapping
+scans that together cover a field of view larger than a single detector frame.
 
-At the APS beamline `2 BM <https://docs2bm.readthedocs.io/en/latest/>`_, these meta data are automatically stored at data collection time in an hdf file compliant with `dxfile <https://dxfile.readthedocs.io/en/latest/index.html>`_ following this layout:
+The full pipeline from raw HDF5 files to a reconstructed 3D volume has the following steps.
+Not all steps are required for every dataset; the table below shows which are optional.
+
+.. list-table::
+   :widths: 5 20 10 65
+   :header-rows: 1
+
+   * - #
+     - Command
+     - Required?
+     - What it does
+   * - 1
+     - ``tile show``
+     - Yes
+     - Verify the dataset — print tile grid, image size, nominal overlap
+   * - 2
+     - ``tile bin``
+     - Optional
+     - Spatially bin raw files to reduce data volume before processing
+   * - 3
+     - ``tile dump-flats``
+     - Optional
+     - Collect a flat field basis for per-projection NNLS flat correction
+   * - 4
+     - ``tile panoramic``
+     - Optional
+     - Quick visual check — save one stitched projection to a tiff
+   * - 5
+     - ``tile center``
+     - Yes
+     - Find the rotation axis location (trial reconstruction stack)
+   * - 6
+     - ``tile shift``
+     - Yes
+     - Fine-tune horizontal tile positions
+   * - 7
+     - ``tile stitch``
+     - Yes
+     - Horizontally stitch all tiles in each y-row → ``tile.h5``
+   * - 8
+     - ``tile vstitch``
+     - Multi-row only
+     - Vertically stitch the per-row ``tile.h5`` files → ``vstitch.h5``
+   * - 9
+     - ``tile double-fov``
+     - 360° scans only
+     - Convert 360° dataset to 180° by stitching paired projections
+   * - 10
+     - ``tomocupy recon``
+     - Yes
+     - Final 3D reconstruction
 
 
-.. image:: img/hdf_00.png
-   :width: 200px
-   :alt: project
+HDF5 metadata requirements
+===========================
 
-.. image:: img/hdf_01.png
-   :width: 200px
-   :alt: project
+tile reads the following metadata from each HDF5 file to sort tiles by position and compute the
+nominal overlap:
 
-.. image:: img/hdf_02.png
-   :width: 200px
-   :alt: project
+#. Sample X position (mm): ``/measurement/instrument/sample_motor_stack/setup/x``
+#. Sample Y position (mm): ``/measurement/instrument/sample_motor_stack/setup/y``
+#. Image resolution (µm/px): ``/measurement/instrument/detection_system/objective/resolution``
+#. Original file name: ``/measurement/sample/file/full_name``
 
-#. sample_x  (mm)         = '/measurement/instrument/sample_motor_stack/setup/x'
-#. sample_y  (mm)         = '/measurement/instrument/sample_motor_stack/setup/y'
-#. resolution (micron)    = '/measurement/instrument/detection_system/objective/resolution'
-#. full_file_name         = '/measurement/sample/file/full_name'
+These paths follow the `dxfile <https://dxfile.readthedocs.io/en/latest/source/demo/doc.areadetector.html#xml>`_
+convention used at `2-BM <https://docs2bm.readthedocs.io/en/latest/>`_,
+`7-BM <https://docs7bm.readthedocs.io/en/latest/>`_, and
+`32-ID <https://docs32id.readthedocs.io/en/latest/>`_.
 
+If your metadata is stored elsewhere, override the paths at runtime::
 
-If these parameters are stored somewhere else in your hdf file, you can set their locations at runtime using the 
---sample-x, --sample-y, --resolution --full-file-name options. 
-
-#. --sample-x '/your_hdf_path/to_sample_x_in_mm'
-#. --sample-y '/your_hdf_path/to_sample_y_in_mm'
-#. --resolution '/your_hdf_path/to_image_resolution_in_micron'
-#. --full-file-name '/your_hdf_path/to_the_full_file_name'
-
-
-By default, these are set to:
-
-#. --sample-x '/measurement/instrument/sample_motor_stack/setup/x'
-#. --sample-y '/measurement/instrument/sample_motor_stack/setup/y'
-#. --resolution '/measurement/instrument/detection_system/objective/resolution'
-#. --full-file-name '/measurement/sample/file/full_name'
-
-to meet the `dxfile <https://dxfile.readthedocs.io/en/latest/source/demo/doc.areadetector.html#xml>`_ definitions for 
-beamlines `2 BM <https://docs2bm.readthedocs.io/en/latest/>`_ , `7 BM <https://docs7bm.readthedocs.io/en/latest/>`_ 
-and `32 ID <https://docs32id.readthedocs.io/en/latest/>`_.
-
-Once the above are confirmed, you can validate the mosaic data set with:
-::
-
-    (tomocupy) tomo@tomo4 $ tile show --folder-name /data/2021-12/Duchkov/mosaic/
-    2022-02-16 11:33:38,485 - Started tile
-    2022-02-16 11:33:38,485 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_11_33_38.log
-    2022-02-16 11:33:38,485 - checking tile files ...
-    2022-02-16 11:33:38,487 - Checking directory: /data/2021-12/Duchkov/mosaic for a tile scan
-    2022-02-16 11:33:38,864 - tile file sorted
-    2022-02-16 11:33:38,865 - x0y0: x = -0.000100; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2073.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2073.h5
-    2022-02-16 11:33:38,865 - x1y0: x = 0.849900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2074.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2074.h5
-    2022-02-16 11:33:38,865 - x2y0: x = 1.699900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2075.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2075.h5
-    2022-02-16 11:33:38,865 - x3y0: x = 2.549900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2076.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2076.h5
-    2022-02-16 11:33:38,865 - x4y0: x = 3.399900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2077.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2077.h5
-    2022-02-16 11:33:39,035 - image   size (x, y) in pixels: (2448, 2048)
-    2022-02-16 11:33:39,035 - tile shift (x, y) in pixels: (2428, 0)
-    2022-02-16 11:33:39,035 - tile overlap (x, y) in pixels: (20, 2048)
-    2022-02-16 11:33:39,040 - tile file name grid:
-                                                 y_0                                          y_1                                          y_2                                          y_3                                          y_4
-    x_0  /data/2021-12/Duchkov/mosaic/mosaic_2073.h5  /data/2021-12/Duchkov/mosaic/mosaic_2074.h5  /data/2021-12/Duchkov/mosaic/mosaic_2075.h5  /data/2021-12/Duchkov/mosaic/mosaic_2076.h5  /data/2021-12/Duchkov/mosaic/mosaic_2077.h5
-
-2. Quick panoramic inspection (optional)
-=========================================
-
-Before running the time-consuming center search, use **tile panoramic** to quickly verify the tile layout and get a visual impression of the nominal overlap quality. It reads a single projection (at the angle set by ``--nprojection``, default 0.5 = midpoint) from each tile, normalizes it, and saves a wide stitched image to ``tile/panoramic.tif``:
-
-::
-
-    (tomocupy) tomo@tomo4 $ tile panoramic --flat-linear True
-
-Open the result in `Fiji ImageJ <https://imagej.net/software/fiji/>`_ to confirm:
-
-- All tiles are present and in the correct order.
-- The nominal overlap looks approximately correct (the seam regions may not be perfect yet — that is fine and expected).
-- The sample fills the expected field of view.
-
-Once you have determined the correct shifts (after running **tile shift**), you can regenerate the panoramic with the corrected positions:
-
-::
-
-    (tomocupy) tomo@tomo4 $ tile panoramic --flat-linear True --x-shifts "[0, 5430, 5419]"
-
-3. Find rotation center
-=======================
-
-**tile center** finds the rotation axis location of the stitched dataset. It stitches all horizontal tiles in the **top row** (y0) of the tile grid using the nominal overlap distance stored in the hdf file, then reconstructs a stack of trial slices over a search range around the specified rotation axis. The vertical sinogram row used is controlled by ``--nsino`` (default 0.5 = vertical center of the detector; adjustable from 0 top to 1 bottom). With ``--binning N``, ``2**N`` consecutive sinogram rows are averaged. The reconstruction is performed with the engine specified by ``--recon-engine`` (tomocupy or tomopy).
-
-.. warning::
-
-   The default value of ``--reverse-grid`` (True) assumes that moving the sample stage in the positive X direction moves the sample to the **left** in the image (as seen by the detector). This is the case at 2-BM after the detector upgrade. If you are using an older setup where positive X moves the sample to the **right**, pass ``--reverse-grid False`` explicitly.
-
-   The default value of ``--file-type`` is ``double_fov``, which is the standard mode at 2-BM. Pass ``--file-type standard`` for single field-of-view datasets.
-
-Use ``--flat-linear True`` when flat fields were collected at the beginning and end of the scan (e.g. 20+20): the first and second halves are averaged separately and linearly interpolated across all projection angles for more accurate normalization.
+    tile show --sample-x '/your/path/to/x' --sample-y '/your/path/to/y'
 
 .. note::
 
-   At this stage only the **center of the reconstructed image** is reliable. The outer regions (left and right "donuts") may look blurry because the nominal tile overlap from the hdf file is only approximate. Ignore the outer regions and focus on the center when selecting the rotation axis.
+   At 2-BM, flat fields are collected at the **end** of each scan with the sample moved to
+   ``SampleOutX``.  Because the HDF attribute is written ``OnFileClose``, the motor RBV at
+   that moment reflects the flat-field position rather than the scan position.  The correct
+   tile X positions are stored in ``/process/acquisition/flat_fields/sample/in_x`` and are
+   read automatically by tile.  If you collected data before this fix was in place, pass the
+   correct path explicitly::
 
-The recommended workflow is **two passes**: a coarse search to locate the approximate center, followed by a fine search to pin it down to sub-pixel accuracy.
+       tile show --sample-x /process/acquisition/flat_fields/sample/in_x
 
-**Pass 1 — coarse search** (wide step, large range):
-
-::
-
-    (tomocupy) tomo@tomo4 ~/conda/tile-decarlof $ tile center --recon-engine tomocupy --rotation-axis 400 --file-type double_fov --binning 2 --nsino-per-chunk 2 --flat-linear True
-    2026-03-24 15:18:38,306 - Started tile
-    2026-03-24 15:18:38,306 - Saving log at /home/beams/TOMO/logs/tile_2026-03-24_15_18_38.log
-    2026-03-24 15:18:38,306 - Run find rotation axis location
-    ...
-    2026-03-24 15:18:41,679 - image   size (x, y) in pixels: (6464, 4852)
-    2026-03-24 15:18:41,679 - stitch shift (x, y) in pixels: (5416, 4561)
-    2026-03-24 15:18:41,679 - tile overlap (x, y) in pixels: (1048, 291)
-    2026-03-24 15:18:48,953 - Created a temporary hdf file: /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5
-    2026-03-24 15:18:48,954 - tomocupy recon --file-type double_fov --binning 2 --reconstruction-type try --file-name /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5             --center-search-width 10.0 --rotation-axis-auto manual --rotation-axis 400.0             --center-search-step 0.5 --end-column -1 --nsino-per-chunk 2 --flat-linear True
-    2026-03-24 15:19:55,427 - Processing slice 0
-    queue size 000 |  |████████████████████████████████████████| 100.0%
-    2026-03-24 15:20:00,821 - Reconstruction time 1.2e+01s
-    2026-03-24 15:20:05,333 - Please open the stack of images from /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile_rec/try_center/tmp/recon* and select the rotation center
-
-Use `Fiji ImageJ <https://imagej.net/software/fiji/>`_  to load the reconstructed slice stack with File/Import/Image Sequence:
-
-.. image:: img/tile_center_00.png
-   :width: 720px
-   :alt: project
-
-
-Zoom into the center region of the image and move the slider:
-
-.. image:: img/tile_center_01.png
-   :width: 720px
-   :alt: project
-
-
-until the center of the image is sharp and free of artifacts:
-
-.. image:: img/tile_center_02.png
-   :width: 720px
-   :alt: project
-
-Note the rotation axis value shown in the top-left corner of the best image (656 in this example). Then re-run with a finer step centered on that value.
-
-**Pass 2 — fine search** (small step, narrow range):
-
-::
-
-    (tomocupy) tomo@tomo4 ~/conda/tile-decarlof $ tile center --recon-engine tomocupy --rotation-axis 656 --file-type double_fov --binning 2 --nsino-per-chunk 2 --flat-linear True --center-search-width 10 --center-search-step 1
-    2026-03-24 16:42:14,152 - Started tile
-    2026-03-24 16:42:14,152 - Saving log at /home/beams/TOMO/logs/tile_2026-03-24_16_42_14.log
-    2026-03-24 16:42:14,152 - Run find rotation axis location
-    ...
-    2026-03-24 16:42:17,524 - image   size (x, y) in pixels: (6464, 4852)
-    2026-03-24 16:42:17,525 - stitch shift (x, y) in pixels: (5416, 4561)
-    2026-03-24 16:42:17,525 - tile overlap (x, y) in pixels: (1048, 291)
-    2026-03-24 16:42:25,225 - Created a temporary hdf file: /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5
-    2026-03-24 16:42:25,226 - tomocupy recon --file-type double_fov --binning 2 --reconstruction-type try --file-name /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile/tmp.h5             --center-search-width 10.0 --rotation-axis-auto manual --rotation-axis 656.0             --center-search-step 1.0 --end-column -1 --nsino-per-chunk 2 --flat-linear True
-    2026-03-24 16:43:31,516 - Processing slice 0
-    queue size 000 |  |████████████████████████████████████████| 100.0%
-    2026-03-24 16:43:36,281 - Reconstruction time 1.1e+01s
-    2026-03-24 16:43:40,757 - Please open the stack of images from /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data/tile_rec/try_center/tmp/recon* and select the rotation center
-
-Inspect the stack again and record the final rotation axis (650 in this example). Store this for the next step.
-
-4. Tile Shift
-=============
-
-**tile center** used the nominal tile overlap distance stored in the hdf file. In this step, **tile shift** fine-tunes each tile's horizontal position. It operates on the **top row (y0)** of the tile grid, using the same sinogram row as ``tile center`` (controlled by ``--nsino``).
-
-For each tile boundary (there are N-1 boundaries for N horizontal tiles), the tool reconstructs a stack of slices by sliding the overlap of the adjacent tile by ``--shift-search-width`` pixels in steps of ``--shift-search-step`` pixels on either side of the nominal position. The total number of shifts tried per boundary is ``2 * shift_search_width / shift_search_step`` (default: 40 shifts per boundary with ``--shift-search-width 20 --shift-search-step 1``).
-
-A progress bar is displayed during processing and, when complete, a color-coded index map is printed:
-
-- **green** indices correspond to negative offsets (tiles closer together than nominal)
-- **red** index corresponds to 0 px offset (perfect motor motion = nominal overlap)
-- **yellow** indices correspond to positive offsets (tiles farther apart than nominal)
-
-The user is then prompted to enter the index of the best-looking frame from the reconstructed stack (or stitched projections), repeating for each tile boundary. The prompt shows the **nominal index** (the one corresponding to 0 px correction), which is the correct answer if motor positioning was perfect.
-
-::
-
-    (tomocupy) tomo@tomo4 ~/conda/tile-decarlof $ tile shift --flat-linear True --rotation-axis 650
-    2026-03-25 15:29:12,127 - Started tile
-    2026-03-25 15:29:12,128 - Saving log at /home/beams/TOMO/logs/tile_2026-03-25_15_29_12.log
-    2026-03-25 15:29:12,128 - Run manual shift
-    2026-03-25 15:29:12,128 - checking tile files ...
-    2026-03-25 15:29:12,128 - Checking directory: /gdata/dm/2BM/2026-03/2026-03-Nikitin-0/data for a tile scan
-    2026-03-25 15:29:14,421 - tile file sorted
-    2026-03-25 15:29:14,422 - x0y0: x = 0.900000; y = -3.000000, file name = .../coffe_beam_mosaic_001.h5
-    2026-03-25 15:29:14,422 - x1y0: x = 2.800000; y = -3.000000, file name = .../coffe_beam_mosaic_002.h5
-    2026-03-25 15:29:14,422 - x2y0: x = 4.700000; y = -3.000000, file name = .../coffe_beam_mosaic_003.h5
-    ...
-    2026-03-25 15:29:15,577 - image   size (x, y) in pixels: (6464, 4852)
-    2026-03-25 15:29:15,577 - stitch shift (x, y) in pixels: (5416, 4561)
-    2026-03-25 15:29:15,577 - tile overlap (x, y) in pixels: (1048, 291)
-    Please enter rotation center (656.2): 650
-    2026-03-25 15:29:16,100 - Processing tile boundary 1 of 2
-      [████████████████████████████████████████] 80/80 (+39 px)
-    Index-to-pixel-offset map for tile 1: 0=-40px, 1=-39px, ... 40=+0px, ... 79=+39px
-    2026-03-25 15:47:00,123 - Please open the stack of images from reconstructions .../tile_rec/tmp_rec/recon* or stitched projections .../tile_rec/tmp_proj/p*, and select the file id to shift tile 1
-    Please enter id for tile 1 shift [nominal: 40] corresponding to 0 pixel shift from the nominal overlap of 1048 px stored in the raw data files:
-
-Use `Fiji ImageJ <https://imagej.net/software/fiji/>`_  to load the reconstructed slice or projection stack with File/Import/Image Sequence:
-
-.. image:: img/tile_shift_00.png
-   :width: 720px
-   :alt: project
-
-
-Zoom into the region of the image separating the two tiles and move the slider:
-
-.. image:: img/tile_shift_01.png
-   :width: 720px
-   :alt: project
-
-
-until the boundary region between the two tiles is sharp and free of artifacts:
-
-.. image:: img/tile_shift_02.png
-   :width: 720px
-   :alt: project
-
-The file name in Fiji's title bar (e.g. ``recon_00054.tif``) tells you the index to enter. In the example above that is index 54, which maps to +14 px from the index-to-pixel-offset map — meaning the stage was 14 pixels (≈ 9 µm at 0.65 µm/px resolution) further apart than the motor position stored in the hdf file.
-
-Pressing **Enter** without typing anything accepts the nominal index (0 px correction).
-
-::
-
-    Please enter id for tile 1 shift [nominal: 40] ...: 54
-    2026-03-25 15:47:02,348 - Selected offset for tile 1: +14 px from nominal (index 54)
-    2026-03-25 15:47:02,349 - Current shifts: [   0 5430 5416]
-
-**tile shift** will now repeat the same process, keeping all previously fixed tiles fixed and sliding the next tile boundary only.
-
-::
-
-    2026-03-25 15:47:02,350 - Processing tile boundary 2 of 2
-      [████████████████████████████████████████] 80/80 (+39 px)
-    Index-to-pixel-offset map for tile 2: 0=-40px, 1=-39px, ... 40=+0px, ... 79=+39px
-    2026-03-25 16:02:14,511 - Please open the stack of images from reconstructions .../tile_rec/tmp_rec/recon* ...
-    Please enter id for tile 2 shift [nominal: 40] corresponding to 0 pixel shift from the nominal overlap of 1048 px stored in the raw data files: 43
-    2026-03-25 16:02:20,812 - Selected offset for tile 2: +3 px from nominal (index 43)
-    2026-03-25 16:02:20,813 - Current shifts: [   0 5430 5419]
-    2026-03-25 16:02:20,814 - Center 650
-    2026-03-25 16:02:20,815 - Relative shifts [0, 5430, 5419]
-
-5. Tile Stitch
-==============
-
-At the end of **tile shift** step, we obtain the final shift list (e.g. ``[0, 5430, 5419]``) that we can use for the final tile stitching. **tile stitch** will generate a single hdf file merging all mosaic tiles with the correct overlap.
-
-::
-
-    (tomocupy) tomo@tomo4 $ tile stitch --folder-name /data/2021-12/Duchkov/mosaic --nproj-per-chunk 128 --x-shifts "[0, 2450, 2450, 2452, 2454]" 
-    2022-02-16 18:30:06,770 - Started tile
-    2022-02-16 18:30:06,770 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_18_30_06.log
-    2022-02-16 18:30:06,770 - Run stitching
-    2022-02-16 18:30:06,770 - checking tile files ...
-    2022-02-16 18:30:06,770 - Checking directory: /data/2021-12/Duchkov/mosaic for a tile scan
-    2022-02-16 18:30:07,146 - tile file sorted
-    2022-02-16 18:30:07,146 - x0y0: x = -0.000100; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2073.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2073.h5
-    2022-02-16 18:30:07,146 - x1y0: x = 0.849900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2074.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2074.h5
-    2022-02-16 18:30:07,146 - x2y0: x = 1.699900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2075.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2075.h5
-    2022-02-16 18:30:07,146 - x3y0: x = 2.549900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2076.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2076.h5
-    2022-02-16 18:30:07,146 - x4y0: x = 3.399900; y = 28.000000, file name = /data/2021-12/Duchkov/mosaic/mosaic_2077.h5, original file name = /local/data/2021-12/Duchkov/mosaic_2077.h5
-    2022-02-16 18:30:07,321 - Relative shifts [   0 2450 2450 2452 2454]
-    2022-02-16 18:30:07,323 - Stitching projections 0 - 128
-    2022-02-16 18:30:20,461 - Stitching projections 128 - 256
-    2022-02-16 18:30:32,099 - Stitching projections 256 - 384
-    2022-02-16 18:30:50,475 - Stitching projections 384 - 512
-    2022-02-16 18:31:12,040 - Stitching projections 512 - 640
-    2022-02-16 18:31:30,324 - Stitching projections 640 - 768
-    2022-02-16 18:31:49,881 - Stitching projections 768 - 896
-    2022-02-16 18:32:08,534 - Stitching projections 896 - 1024
-    2022-02-16 18:32:26,784 - Stitching projections 1024 - 1152
-    2022-02-16 18:32:47,320 - Stitching projections 1152 - 1280
-    2022-02-16 18:33:04,260 - Stitching projections 1280 - 1408
-    2022-02-16 18:33:23,326 - Stitching projections 1408 - 1536
-    2022-02-16 18:33:41,526 - Stitching projections 1536 - 1664
-    2022-02-16 18:34:00,341 - Stitching projections 1664 - 1792
-    2022-02-16 18:34:18,362 - Stitching projections 1792 - 1920
-    2022-02-16 18:34:37,191 - Stitching projections 1920 - 2048
-    2022-02-16 18:34:55,829 - Stitching projections 2048 - 2176
-    2022-02-16 18:35:15,554 - Stitching projections 2176 - 2304
-    2022-02-16 18:35:33,733 - Stitching projections 2304 - 2432
-    2022-02-16 18:35:58,429 - Stitching projections 2432 - 2560
-    2022-02-16 18:36:16,669 - Stitching projections 2560 - 2688
-    2022-02-16 18:36:37,403 - Stitching projections 2688 - 2816
-    2022-02-16 18:37:01,131 - Stitching projections 2816 - 2944
-    2022-02-16 18:37:21,374 - Stitching projections 2944 - 3072
-    2022-02-16 18:37:40,137 - Stitching projections 3072 - 3200
-    2022-02-16 18:37:55,265 - Stitching projections 3200 - 3328
-    2022-02-16 18:38:13,574 - Stitching projections 3328 - 3456
-    2022-02-16 18:38:35,979 - Stitching projections 3456 - 3584
-    2022-02-16 18:38:57,068 - Stitching projections 3584 - 3712
-    2022-02-16 18:39:16,547 - Stitching projections 3712 - 3840
-    2022-02-16 18:39:40,333 - Stitching projections 3840 - 3968
-    2022-02-16 18:40:01,126 - Stitching projections 3968 - 4096
-    2022-02-16 18:40:23,886 - Stitching projections 4096 - 4224
-    2022-02-16 18:40:44,862 - Stitching projections 4224 - 4352
-    2022-02-16 18:41:08,228 - Stitching projections 4352 - 4480
-    2022-02-16 18:41:30,260 - Stitching projections 4480 - 4608
-    2022-02-16 18:41:52,968 - Stitching projections 4608 - 4736
-    2022-02-16 18:42:14,439 - Stitching projections 4736 - 4864
-    2022-02-16 18:42:36,661 - Stitching projections 4864 - 4992
-    2022-02-16 18:42:58,154 - Stitching projections 4992 - 5120
-    2022-02-16 18:43:21,760 - Stitching projections 5120 - 5248
-    2022-02-16 18:43:43,310 - Stitching projections 5248 - 5376
-    2022-02-16 18:44:04,637 - Stitching projections 5376 - 5504
-    2022-02-16 18:44:22,942 - Stitching projections 5504 - 5632
-    2022-02-16 18:44:45,562 - Stitching projections 5632 - 5760
-    2022-02-16 18:45:03,388 - Stitching projections 5760 - 5888
-    2022-02-16 18:45:23,980 - Stitching projections 5888 - 6000
-    2022-02-16 18:55:02,606 - Output file /data/2021-12/Duchkov/mosaic/tile/tile.h5
-    2022-02-16 19:03:41,109 - Reconstruct /data/2021-12/Duchkov/mosaic/tile/tile.h5 with tomocupy:
-    2022-02-16 19:03:41,110 - tomocupy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
-    2022-02-16 19:03:41,110 - Reconstruct /data/2021-12/Duchkov/mosaic/tile/tile.h5 with tomopy:
-    2022-02-16 19:03:41,110 - tomopy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
-
-6. Tile reconstruction
-======================
-
-Once the stitching is completed the tomographic reconstruction can be done with `tomocupy <https://tomocupy.readthedocs.io/en/latest/>`_ or `tomopy <https://tomopy.readthedocs.io/en/latest/>`_/`tomopycli <https://tomopycli.readthedocs.io/en/latest/>`_:
-
-with **tomocupy**
-::
- 
-    (tomocupy) tomo@tomo4 $ tomocupy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
-
-with **tomopy**
-::
- 
-    (tomocupy) tomo@tomo4 $ tomopy recon --file-name /data/2021-12/Duchkov/mosaic/tile/tile.h5 --rotation-axis 1246 --reconstruction-type full --file-type double_fov --remove-stripe-method fw --binning 0 --nsino-per-chunk 8 --rotation-axis-auto manual
-
-For more options:
-::
-
-    (tomocupy) tomo@tomo4 $ tile -h
-    (tomocupy) tomo@tomo4 $ tile stitch -h
-    (tomocupy) tomo@tomo4 $ tile shift -h
-
-
-Quick Start Guide
-=================
-
-This section summarizes the full mosaic reconstruction workflow in plain language for new users.
-
-**What you have:** a set of hdf5 files, each containing a tomographic scan of one tile of the sample. The tiles overlap slightly and together cover a field of view larger than a single scan.
-
-**What you want:** a single reconstructed 3D volume of the full sample.
-
-The process has six steps (step 2 is optional):
 
 ----
 
 Step 1 — Verify the dataset (``tile show``)
---------------------------------------------
+===========================================
 
-**What it does:**
+Read the HDF metadata from every tile file, sort them by motor position, and print the tile
+grid layout, image size, and nominal overlap::
 
-Reads the hdf metadata from all tile files, sorts them by motor position, and prints the tile grid layout, image size, and nominal overlap. Use this to confirm all tiles are present and correctly ordered before doing anything else.
+    (tile) tomo@tomo4 $ tile show --folder-name /data/2021-12/Duchkov/mosaic/
+    2022-02-16 11:33:38,485 - Started tile
+    2022-02-16 11:33:38,485 - Saving log at /home/beams/TOMO/logs/tile_2022-02-16_11_33_38.log
+    2022-02-16 11:33:38,485 - checking tile files ...
+    2022-02-16 11:33:38,485 - Checking directory: /data/2021-12/Duchkov/mosaic for a tile scan
+    2022-02-16 11:33:38,780 - tile file sorted
+    2022-02-16 11:33:38,780 - x0y0: x = -0.0001; y = 28.0, file name = .../mosaic_2073.h5
+    2022-02-16 11:33:38,780 - x1y0: x =  0.8499; y = 28.0, file name = .../mosaic_2074.h5
+    ...
+    2022-02-16 11:33:38,918 - image   size (x, y) in pixels: (2448, 2048)
+    2022-02-16 11:33:38,918 - tile shift (x, y) in pixels: (2428, 0)
+    2022-02-16 11:33:38,918 - tile overlap (x, y) in pixels: (20, 2048)
+    2022-02-16 11:33:38,918 - tile file name grid:
+                                              y_0
+    x_0  /data/2021-12/Duchkov/mosaic/mosaic_2073.h5
+    x_1  /data/2021-12/Duchkov/mosaic/mosaic_2074.h5
+    ...
 
-::
+Check that:
 
-    (tomocupy) tomo@tomo4 $ tile show --folder-name /path/to/data
+- All expected tiles are present and in the correct row/column positions.
+- The nominal overlap (``tile overlap``) is a reasonable fraction of the tile width
+  (typically 5–20%).
+
+.. warning::
+
+   ``--reverse-grid True`` (the default at 2-BM) reverses the tile order within each row,
+   so that tile x0 is placed at the left of the stitched image.  This matches the 2-BM
+   detector geometry where positive motor X moves the sample to the **left** in the image.
+   Pass ``--reverse-grid False`` if positive X moves the sample to the **right**.
+
 
 ----
 
-Step 2 — Quick panoramic inspection (optional, ``tile panoramic``)
-------------------------------------------------------------------
+Step 2 — Bin raw files (``tile bin``) — *optional*
+===================================================
 
-**What it does:**
+For large datasets (e.g. 6000 projections × 4852 × 6464 px per tile) it is practical to work
+on a spatially-binned copy during the alignment steps (center search, shift tuning).  Once the
+parameters are confirmed on the binned data the final stitch can be done at full resolution.
 
-Reads a single projection from each tile, normalizes it, and saves a wide stitched image to ``tile/panoramic.tif`` using the nominal overlap from the hdf file (or ``--x-shifts`` if provided). Open the result in Fiji to visually confirm the tile layout and get a sense of the overlap quality before running the longer center search.
+``tile bin`` copies all ``.h5`` files from ``--folder-name``, applies ``2**binning × 2**binning``
+spatial binning to the exchange datasets, and optionally subsamples every ``--bin-step``\th
+projection.  Output files are written to ``<folder-name>/bin<N>x<N>/`` by default::
 
-::
+    (tile) tomo@tomo4 $ tile bin --folder-name /data/raw/ --binning 1 --bin-step 2
+    # → outputs to /data/raw/bin2x2/  (2×2 spatial bin, every 2nd projection)
 
-    (tomocupy) tomo@tomo4 $ tile panoramic --flat-linear True
+    (tile) tomo@tomo4 $ tile bin --folder-name /data/raw/ --binning 2 --bin-step 1
+    # → outputs to /data/raw/bin4x4/  (4×4 spatial bin, all projections)
+
+For a multi-row mosaic where each row lives in a separate subfolder, run ``tile bin`` once per
+row folder::
+
+    for ydir in y0 y1 y2 y3; do
+        tile bin --folder-name /data/raw/$ydir/ --binning 1 --bin-step 2
+    done
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--binning N``
+     - Spatial bin factor = 2\ :sup:`N` (0=none, 1=2×2, 2=4×4, …)
+   * - ``--bin-step N``
+     - Keep every Nth projection (1 = keep all)
+   * - ``--bin-output-dir PATH``
+     - Override the default output directory
+
 
 ----
 
-Step 3 — Find the rotation center (``tile center``)
-----------------------------------------------------
+Step 3 — Collect flat field basis (``tile dump-flats``) — *optional*
+=====================================================================
 
-**What it does:**
+``tile dump-flats`` collects flat fields from all tile HDF5 files and saves them as a basis
+file for per-projection NNLS flat correction.  For each input file it writes two averaged
+frames: the mean of the first half and the mean of the second half of the flat field frames.
+This basis is then passed to subsequent commands via ``--flats-file``.
 
-Takes all horizontal tiles from the top row of the mosaic, stitches them side by side using the nominal overlap stored in the hdf file, and reconstructs a stack of trial images — each one using a slightly different rotation axis position. You inspect the stack and pick the sharpest image.
+Use this when:
+
+- Flat field illumination varies significantly across the scan (beam intensity drift, ring
+  artifacts from a specific flat, etc.).
+- You want per-projection flat correction rather than a simple averaged flat.
+
+For a single-folder dataset::
+
+    (tile) tomo@tomo4 $ tile dump-flats --folder-name /data/raw/bin2x2/ \
+                                        --dump-flats-output flats.h5
+    # → writes /data/raw/bin2x2/flats.h5
+
+For a multi-row dataset where each row lives in a subfolder::
+
+    (tile) tomo@tomo4 $ tile dump-flats --folder-name /data/raw/bin2x2/ \
+                                        --y-folders y0,y1,y2,y3 \
+                                        --dump-flats-output flats.h5
+    # → collects flats from y0/, y1/, y2/, y3/  and writes /data/raw/bin2x2/flats.h5
+
+The resulting ``flats.h5`` is passed to ``tile center``, ``tile shift``, and ``tile stitch``
+via the ``--flats-file`` option.
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--y-folders``
+     - Comma-separated subfolder names (e.g. ``y0,y1,y2,y3``).  Leave empty to use
+       ``--folder-name`` directly.
+   * - ``--dump-flats-output``
+     - Output filename inside ``--folder-name`` (default: ``flats.h5``)
+   * - ``--reverse-step``
+     - Flip the X direction when reading flats (``True``/``False``, default ``False``)
+
+
+----
+
+Step 4 — Quick panoramic inspection (``tile panoramic``) — *optional*
+======================================================================
+
+Before running the time-consuming center search, use ``tile panoramic`` to visually confirm
+the tile layout.  It reads a single projection (at the angle set by ``--nprojection``, default
+0.5 = midpoint) from each tile, normalises it, and saves a wide stitched image to
+``tile/panoramic.tif`` in the dataset folder::
+
+    (tile) tomo@tomo4 $ tile panoramic --flat-linear True
+
+Open the result in `Fiji ImageJ <https://imagej.net/software/fiji/>`_ to confirm:
+
+- All tiles are present and in the correct left-to-right order.
+- The nominal overlap looks approximately correct (seam regions may not be perfect yet).
+- The sample fills the expected field of view.
+
+Once you have the correct shifts from ``tile shift``, you can regenerate the panoramic with
+the corrected positions to verify the alignment::
+
+    (tile) tomo@tomo4 $ tile panoramic --flat-linear True --x-shifts "[0, 5430, 5419]"
+
+Pass ``--show`` to display the image interactively in a matplotlib window (requires a display).
+
+
+----
+
+Step 5 — Find the rotation center (``tile center``)
+====================================================
+
+``tile center`` stitches all horizontal tiles in the **top row** of the mosaic using the
+nominal overlap from the HDF file, then reconstructs a stack of trial slices, each with a
+slightly different rotation axis position.  You inspect the stack and pick the sharpest image.
+
+The sinogram row used is controlled by ``--nsino`` (0 = top, 1 = bottom, default 0.5 =
+vertical centre of the detector).  With ``--binning N``, ``2**N`` consecutive rows are
+averaged to improve signal.
+
+.. warning::
+
+   Only the **centre of the reconstructed image** is reliable at this stage.  The outer
+   regions may look blurry because the nominal tile overlap is only approximate.  Ignore
+   those regions and focus on the centre when selecting the rotation axis.
+
+.. warning::
+
+   ``--file-type double_fov`` (the default) tells tomocupy to treat the input as a 360°
+   scan and mirror the sinogram.  This is the standard mode at 2-BM for 360° acquisitions.
+   Pass ``--file-type standard`` for ordinary 180° scans.
+
+**Recommended workflow — two passes:**
+
+*Pass 1 — coarse search* (wide step, large range)::
+
+    (tile) tomo@tomo4 $ tile center --recon-engine tomocupy \
+        --rotation-axis 400 --center-search-width 200 --center-search-step 10 \
+        --file-type double_fov --binning 2 --nsino-per-chunk 2 --flat-linear True
+
+Open the try-center stack from::
+
+    /path/to/data/tile_rec/try_center/tmp/recon*
+
+in Fiji (File → Import → Image Sequence).  Zoom into the **centre** of the image and move the
+slider until the reconstruction looks sharp and ring-free.  Note the rotation axis value shown
+in the top-left corner of the best image.
+
+*Pass 2 — fine search* (small step, narrow range)::
+
+    (tile) tomo@tomo4 $ tile center --recon-engine tomocupy \
+        --rotation-axis 656 --center-search-width 10 --center-search-step 1 \
+        --file-type double_fov --binning 2 --nsino-per-chunk 2 --flat-linear True
+
+Record the final rotation axis value (e.g. 650) for the next step.
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--rotation-axis``
+     - Starting guess for the rotation axis (pixels).  Use -1 to default to image centre.
+   * - ``--center-search-width``
+     - Half-width of the search range (pixels).
+   * - ``--center-search-step``
+     - Step size between trials (pixels).
+   * - ``--nsino``
+     - Relative vertical position of the sinogram row (0–1).
+   * - ``--binning``
+     - Spatial binning (0=none, 1=2×, 2=4×).
+   * - ``--nsino-per-chunk``
+     - Number of sinogram rows averaged per chunk (increase for better SNR).
+   * - ``--flat-linear True``
+     - Enable linear interpolation of flat fields across the scan.
+   * - ``--flats-file PATH``
+     - Use per-projection NNLS flat correction from a ``dump-flats`` basis file.
+   * - ``--file-type``
+     - ``double_fov`` (default, 360° scans) or ``standard`` (180° scans).
+   * - ``--recon-engine``
+     - ``tomocupy`` (default) or ``tomopy``.
+
+
+----
+
+Step 6 — Fine-tune tile shifts (``tile shift``)
+================================================
+
+``tile center`` used the nominal overlap stored in the HDF file.  ``tile shift`` refines each
+horizontal tile position one boundary at a time, keeping all previously fixed tiles fixed and
+sliding only the next tile.
+
+For each boundary between adjacent tiles, it reconstructs a stack of slices by shifting the
+overlap by ``--shift-search-width`` pixels in steps of ``--shift-search-step`` on either side
+of the nominal position.  A colour-coded index map is printed:
+
+- **green** = negative offset (tiles closer than nominal)
+- **red** = 0 offset (perfect motor positioning = nominal overlap)
+- **yellow** = positive offset (tiles farther than nominal)
+
+::
+
+    (tile) tomo@tomo4 $ tile shift --rotation-axis 650 --flat-linear True \
+        --shift-search-width 60 --shift-search-step 1
+    ...
+    Please enter rotation center (656.2): 650
+    ...
+    Please enter id for tile 1 shift [nominal: 60] ...: 74
+    2026-03-25 15:47:02,348 - Selected offset for tile 1: +14 px (index 74)
+    2026-03-25 15:47:02,349 - Current shifts: [0 5430 5416]
+    ...
+    Please enter id for tile 2 shift [nominal: 60] ...: 63
+    2026-03-25 16:02:20,813 - Selected offset for tile 2: +3 px (index 63)
+    2026-03-25 16:02:20,813 - Current shifts: [0 5430 5419]
+    2026-03-25 16:02:20,814 - Center 650
+    2026-03-25 16:02:20,815 - Relative shifts [0, 5430, 5419]
+
+Inspect the try-recon stack or the stitched projection stack in Fiji.  Zoom into the **boundary
+region** between the two tiles and move the slider until the seam is sharp and artifact-free.
+The file name in Fiji's title bar gives the index to enter (pressing Enter accepts the nominal).
+
+Record the final shift list (e.g. ``[0, 5430, 5419]``) for the next step.
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--rotation-axis``
+     - Rotation axis found in Step 5.
+   * - ``--shift-search-width``
+     - Half-width of the shift search in pixels (default 20).
+   * - ``--shift-search-step``
+     - Step size between shift trials in pixels (default 1).
+   * - ``--flat-linear True``
+     - As in Step 5.
+   * - ``--x-shifts``
+     - Provide pre-computed shifts to skip the interactive search (e.g. from a previous run).
+
+
+----
+
+Step 7 — Horizontal stitch (``tile stitch``)
+=============================================
+
+``tile stitch`` merges all tiles for each y-row into a single HDF5 file (``tile.h5``) using
+the confirmed x-shifts.  The output file has flat/dark correction already applied
+(``data_white=1``, ``data_dark=0``) so that subsequent steps (vstitch, double-fov,
+reconstruction) do not need to repeat it.
+
+For a **single-row** mosaic::
+
+    (tile) tomo@tomo4 $ tile stitch --folder-name /data/mosaic/ \
+        --x-shifts "[0, 2450, 2450, 2452, 2454]" \
+        --rotation-axis 1246 --flat-linear True
+
+For a **multi-row** mosaic, run ``tile stitch`` once per y-row::
+
+    for k in 0 1 2 3; do
+        tile stitch --folder-name /data/bin2x2/y$k/ \
+            --x-shifts "[0, 2752, 2752]" \
+            --rotation-axis 324 --flat-linear True \
+            --flats-file /data/bin2x2/flats.h5 --zinger-level 0.08
+    done
+
+Each run writes ``<folder-name>/tile/tile.h5``.
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--x-shifts``
+     - Cumulative pixel shifts from Step 6, e.g. ``"[0, 5430, 5419]"``.  Required.
+   * - ``--rotation-axis``
+     - Rotation axis from Step 5 (used when ``--recon True``).
+   * - ``--flat-linear True``
+     - Linear flat-field interpolation per projection.
+   * - ``--flats-file PATH``
+     - Per-projection NNLS flat correction (from ``tile dump-flats``).
+   * - ``--zinger-level``
+     - Zinger removal threshold as fraction above local temporal median (0 = disabled,
+       0.08 = 8%).  A value of 0 disables zinger removal.
+   * - ``--nproj-per-chunk``
+     - Projections processed per chunk (increase for faster I/O, at the cost of memory).
+   * - ``--max-workers``
+     - Number of parallel threads for chunk processing.
+   * - ``--start-proj / --end-proj``
+     - Process only a subset of projections (useful for splitting a large job).
+   * - ``--recon True/False``
+     - Whether to also run a quick reconstruction after stitching (default True).
+
+
+----
+
+Step 8 — Vertical stitch (``tile vstitch``) — *multi-row only*
+===============================================================
+
+For a mosaic with multiple y-rows, ``tile vstitch`` stacks the per-row ``tile.h5`` files
+vertically into a single ``vstitch.h5``.  It uses quintic blending in the overlap region and
+applies per-projection intensity scale calibration between adjacent rows to smooth brightness
+differences.
+
+Determine the y-shifts between rows (in pixels) by inspecting a single projection from each
+row's ``tile.h5`` and measuring the vertical overlap::
+
+    (tile) tomo@tomo4 $ tile vstitch \
+        --folder-name /data/bin2x2/ \
+        --y-folders y0,y1,y2,y3 \
+        --y-shifts "[0, 450, 450, 450]" \
+        --vstitch-output vstitch.h5
+
+Alternatively, pass an explicit glob pattern::
+
+    (tile) tomo@tomo4 $ tile vstitch \
+        --folder-name /data/bin2x2/ \
+        --vstitch-pattern "/data/bin2x2/y*/tile/tile.h5" \
+        --y-shifts "[0, 450, 450, 450]"
+
+Output: ``<folder-name>/vstitch.h5`` (or as set by ``--vstitch-output``).
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--y-shifts``
+     - Cumulative y-shifts between rows in pixels, e.g. ``"[0, 450, 450, 450]"``.  Required.
+   * - ``--y-folders``
+     - Comma-separated subfolder names (e.g. ``y0,y1,y2,y3``).
+   * - ``--vstitch-pattern``
+     - Explicit glob pattern overriding ``--y-folders`` (e.g. ``y*/tile/tile.h5``).
+   * - ``--vstitch-output``
+     - Output filename relative to ``--folder-name`` (default ``vstitch.h5``).
+   * - ``--nproj-per-chunk``
+     - Projections processed per chunk.
+   * - ``--max-workers``
+     - Number of parallel threads.
+
+
+----
+
+Step 9 — 360° to 180° conversion (``tile double-fov``) — *360° scans only*
+===========================================================================
+
+For 360° acquisitions, ``tile double-fov`` converts the dataset to an effective 180° scan
+by stitching projection ``i`` with ``fliplr(projection[i + N/2])``.  The rotation axis position
+controls the amount of overlap/shift between the two halves.
+
+The output is a half-sized projection stack (N/2 projections × full stitched width) ready
+for standard 180° reconstruction::
+
+    (tile) tomo@tomo4 $ tile double-fov \
+        --folder-name /data/bin2x2/ \
+        --double-fov-input vstitch.h5 \
+        --double-fov-output double_fov.h5 \
+        --rotation-axis 1627
+
+Key parameters:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 0
+
+   * - ``--rotation-axis``
+     - Rotation axis position in the input file (pixels from left edge).  Required.
+   * - ``--double-fov-input``
+     - Input HDF5 file (relative to ``--folder-name`` or absolute, default ``vstitch.h5``).
+   * - ``--double-fov-output``
+     - Output HDF5 file (default ``double_fov.h5``).
+   * - ``--nproj-per-chunk``
+     - Projections processed per chunk.
+   * - ``--max-workers``
+     - Number of parallel threads.
+
+
+----
+
+Step 10 — Reconstruction
+=========================
+
+Once the final stitched file is ready, reconstruct with
+`tomocupy <https://tomocupy.readthedocs.io/en/latest/>`_ or
+`tomopy <https://tomopy.readthedocs.io/en/latest/>`_/`tomopycli <https://tomopycli.readthedocs.io/en/latest/>`_.
+
+**Single-row mosaic** (``tile/tile.h5``, 180° scan)::
+
+    (tomocupy) tomo@tomo4 $ tomocupy recon \
+        --file-name /data/mosaic/tile/tile.h5 \
+        --rotation-axis 1246 \
+        --reconstruction-type full \
+        --file-type standard \
+        --binning 0 --nsino-per-chunk 8 \
+        --rotation-axis-auto manual
+
+**Multi-row 360° mosaic** (``double_fov.h5``, already converted to 180°)::
+
+    (tomocupy) tomo@tomo4 $ tomocupy recon \
+        --file-name /data/bin2x2/double_fov.h5 \
+        --rotation-axis 1627 \
+        --reconstruction-type full \
+        --file-type standard \
+        --binning 0 --nsino-per-chunk 8 \
+        --rotation-axis-auto manual
 
 .. note::
 
-   Only the **center of the reconstructed image** is reliable at this stage. The outer regions (left and right "donuts") may look blurry because the nominal tile overlap from the hdf file is only approximate. Ignore the outer regions for now and focus on the center.
+   After ``tile double-fov`` the file is already a 180° dataset, so pass
+   ``--file-type standard``.  Use ``--file-type double_fov`` only if you are passing the
+   raw stitched ``tile.h5`` directly to tomocupy without the explicit double-fov conversion.
 
-**How to run (two passes recommended):**
+For all options::
 
-*Pass 1 — coarse:* start with a large search range to find the approximate center::
+    (tile) tomo@tomo4 $ tile -h
+    (tile) tomo@tomo4 $ tile stitch -h
+    (tile) tomo@tomo4 $ tile vstitch -h
+    (tile) tomo@tomo4 $ tile double-fov -h
 
-    (tomocupy) tomo@tomo4 $ tile center --recon-engine tomocupy --file-type double_fov \
-        --binning 2 --nsino-per-chunk 2 --flat-linear True \
-        --rotation-axis 400 --center-search-width 100 --center-search-step 5
-
-Open the output stack in Fiji (File → Import → Image Sequence), zoom into the **center of the image**, and move the slider until the center region is sharp. Note the rotation axis value shown in the top-left corner of the best image (e.g. 656).
-
-*Pass 2 — fine:* narrow the search around the value you found::
-
-    (tomocupy) tomo@tomo4 $ tile center --recon-engine tomocupy --file-type double_fov \
-        --binning 2 --nsino-per-chunk 2 --flat-linear True \
-        --rotation-axis 656 --center-search-width 5 --center-search-step 0.1
-
-Repeat the Fiji inspection and record the final value (e.g. **656.2**). This is your rotation center.
 
 ----
 
-Step 4 — Fine-tune the tile overlap positions (``tile shift``)
----------------------------------------------------------------
+Complete workflow example — 4×3 mosaic, 360° scan
+==================================================
 
-**What it does:**
-
-The nominal overlap from the hdf file is only approximate (limited by stage positioning accuracy, typically a few micrometers). This step fine-tunes the horizontal position of each tile relative to its neighbor so that the full stitched image — including the outer "donut" regions — is sharp.
-
-It works tile by tile, left to right. For each tile boundary it tries sliding the adjacent tile by ±20 pixels (adjustable) from the nominal position and reconstructs a stack for you to inspect. You pick the frame where the **boundary region between the two tiles** looks sharpest and seamless.
-
-**How to run:**
+This example follows the processing of a 4-row × 3-column coffee bean mosaic collected at
+2-BM in March 2026.  Each row lives in a separate subfolder ``y0``–``y3`` under the data
+directory and the scan is a 360° acquisition.
 
 ::
 
-    (tomocupy) tomo@tomo4 $ tile shift --flat-linear True --rotation-axis 656.2
+    DATA=/data/raw                  # raw files in DATA/y0/, DATA/y1/, DATA/y2/, DATA/y3/
+    BIN=/data/bin2x2                # working directory (2×2 binned, every 2nd projection)
 
-When prompted, confirm or update the rotation center. For each tile boundary the tool:
+    # 1. Verify the dataset (use any y-row)
+    tile show --folder-name $DATA/y0/
 
-1. Runs the reconstruction for all candidate shifts (progress bar displayed).
-2. Prints a color-coded index map: **green** = negative offset, **red** = nominal (0 px), **yellow** = positive offset.
-3. Asks you to enter an index.
+    # 2. Bin all rows
+    for k in 0 1 2 3; do
+        tile bin --folder-name $DATA/y$k/ --binning 1 --bin-step 2
+    done
 
-Then:
+    # 3. Collect flat field basis
+    tile dump-flats --folder-name $BIN --y-folders y0,y1,y2,y3 \
+        --dump-flats-output flats.h5
 
-1. Open the reconstruction stack ``tile_rec/tmp_rec/recon*`` **or** the projection stack ``tile_rec/tmp_proj/p*`` in Fiji.
-2. Zoom into the **overlap region between the two tiles** (not the center of the image).
-3. Move the slider until the boundary is sharp and artifact-free.
-4. Read the index from the file name shown by Fiji (e.g. ``recon_00054.tif`` → index 54) and enter it at the prompt.
+    # 4. Quick panoramic (top row only)
+    tile panoramic --folder-name $BIN/y0/ --flat-linear True
 
-.. note::
+    # 5. Find rotation center (coarse)
+    tile center --folder-name $BIN/y0/ --recon-engine tomocupy \
+        --rotation-axis 400 --center-search-width 200 --center-search-step 10 \
+        --file-type double_fov --binning 0 --nsino-per-chunk 2 --flat-linear True
+    # → open $BIN/y0/tile_rec/try_center/tmp/recon* in Fiji, pick best frame → e.g. 324
 
-   The prompt shows ``[nominal: 40]`` (or whichever index corresponds to 0 px offset). Pressing **Enter** without typing accepts the nominal, which is correct when stage positioning is perfect. A selection of 54 where nominal is 40 means the stage was +14 px (≈ 9 µm at 0.65 µm/px) farther apart than the hdf file recorded.
+    # 5b. Fine search
+    tile center --folder-name $BIN/y0/ --recon-engine tomocupy \
+        --rotation-axis 324 --center-search-width 10 --center-search-step 1 \
+        --file-type double_fov --binning 0 --nsino-per-chunk 2 --flat-linear True
+    # → confirmed rotation axis = 324
 
-Repeat for each tile boundary. At the end the tool prints the final shift array, e.g.::
+    # 6. Find tile shifts
+    tile shift --folder-name $BIN/y0/ --rotation-axis 324 --flat-linear True \
+        --shift-search-width 60 --shift-search-step 1
+    # → confirmed x-shifts = [0, 2752, 2752]
 
-    Current shifts: [0, 5430, 5419]
+    # 7. Stitch all rows
+    for k in 0 1 2 3; do
+        tile stitch --folder-name $BIN/y$k/ \
+            --x-shifts "[0, 2752, 2752]" \
+            --rotation-axis 324 --flat-linear True \
+            --flats-file $BIN/flats.h5 --zinger-level 0.08
+    done
+    # → $BIN/y*/tile/tile.h5
 
-Save this for the next step.
+    # 8. Vertical stitch
+    tile vstitch --folder-name $BIN \
+        --y-folders y0,y1,y2,y3 \
+        --y-shifts "[0, 450, 450, 450]" \
+        --vstitch-output vstitch.h5
+    # → $BIN/vstitch.h5
 
-----
+    # 9. 360° → 180° conversion
+    tile double-fov --folder-name $BIN \
+        --double-fov-input vstitch.h5 \
+        --double-fov-output double_fov.h5 \
+        --rotation-axis 1627
+    # → $BIN/double_fov.h5
 
-Step 5 — Stitch all tiles into a single file (``tile stitch``)
----------------------------------------------------------------
-
-**What it does:**
-
-Uses the corrected overlap positions from Step 2 to merge all mosaic tiles (all rows, all projections) into a single hdf5 file ready for reconstruction.
-
-**How to run:**
-
-::
-
-    (tomocupy) tomo@tomo4 $ tile stitch --x-shifts "[0, 5418, 5420]" --nproj-per-chunk 128
-
-The output file is written to ``tile/tile.h5`` inside your data folder.
-
-----
-
-Step 6 — Reconstruct (``tomocupy`` or ``tomopy``)
---------------------------------------------------
-
-**What it does:**
-
-Runs the full tomographic reconstruction on the stitched file.
-
-**How to run:**
-
-::
-
-    (tomocupy) tomo@tomo4 $ tomocupy recon --file-name /path/to/tile/tile.h5 \
-        --rotation-axis 656.2 --reconstruction-type full \
-        --file-type double_fov --flat-linear True \
-        --remove-stripe-method fw --binning 0 \
-        --nsino-per-chunk 4 --rotation-axis-auto manual
+    # 10. Reconstruct
+    tomocupy recon \
+        --file-name $BIN/double_fov.h5 \
+        --rotation-axis 1627 \
+        --reconstruction-type full \
+        --file-type standard \
+        --binning 0 --nsino-per-chunk 8 \
+        --rotation-axis-auto manual

--- a/tile/config.py
+++ b/tile/config.py
@@ -184,7 +184,12 @@ SECTIONS['center'] = {
         'type': int,
         'default': -1,
         'help': 'End column in x',
-    }
+    },
+    'file-type': {
+        'type': str,
+        'default': 'standard',
+        'help': "Tomocupy file type: standard or double_fov",
+    },
 }
 
 

--- a/tile/config.py
+++ b/tile/config.py
@@ -229,14 +229,68 @@ SECTIONS['shift'] = {
         'help': "+/- center search step (pixel). "},
     }
 
-INFO_PARAMS      = ('file-io',)
-CENTER_PARAMS    = ('file-io', 'center')
-SHIFT_PARAMS     = ('file-io', 'center', 'shift')
-STITCH_PARAMS    = ('file-io', 'center', 'stitch')
-PANORAMIC_PARAMS = ('file-io', 'center', 'stitch')
-ALL_PARAMS    = ('file-io', 'center', 'shift', 'stitch')
+SECTIONS['bin'] = {
+    'bin-step': {
+        'default': 1,
+        'type': int,
+        'help': "Projection subsampling step (keep every Nth projection). 1 = keep all."},
+    'bin-output-dir': {
+        'default': '',
+        'type': str,
+        'help': "Output directory for binned files. Default: <folder-name>/bin<N>x<N>/ derived from --binning."},
+}
 
-NICE_NAMES = ('General', 'File IO', 'Center', 'Shift', 'Stitch')
+SECTIONS['dump-flats'] = {
+    'dump-flats-output': {
+        'default': 'flats.h5',
+        'type': str,
+        'help': "Output file name for the flat field basis (written inside --folder-name)."},
+    'y-folders': {
+        'default': '',
+        'type': str,
+        'help': "Comma-separated list of y-row subfolders inside --folder-name (e.g. 'y0,y1,y2,y3'). "
+                "Empty = use --folder-name directly."},
+}
+
+SECTIONS['vstitch'] = {
+    'y-shifts': {
+        'default': 'None',
+        'type': str,
+        'help': "Comma-separated cumulative y shifts between tile rows, e.g. '[0,450,450]'. Required."},
+    'vstitch-output': {
+        'default': 'vstitch.h5',
+        'type': str,
+        'help': "Output file name for the vertically stitched dataset (written inside --folder-name)."},
+    'vstitch-pattern': {
+        'default': '',
+        'type': str,
+        'help': "Glob pattern for input tile.h5 files. "
+                "Default (empty): <folder-name>/<y-folders>/tile/tile.h5 or <folder-name>/tile/tile.h5."},
+}
+
+SECTIONS['double-fov'] = {
+    'double-fov-input': {
+        'default': 'vstitch.h5',
+        'type': str,
+        'help': "Input HDF5 file for 360→180 conversion (relative to --folder-name or absolute)."},
+    'double-fov-output': {
+        'default': 'double_fov.h5',
+        'type': str,
+        'help': "Output HDF5 file after 360→180 conversion (relative to --folder-name or absolute)."},
+}
+
+INFO_PARAMS        = ('file-io',)
+CENTER_PARAMS      = ('file-io', 'center')
+SHIFT_PARAMS       = ('file-io', 'center', 'shift')
+STITCH_PARAMS      = ('file-io', 'center', 'stitch')
+PANORAMIC_PARAMS   = ('file-io', 'center', 'stitch')
+BIN_PARAMS         = ('file-io', 'bin')
+DUMP_FLATS_PARAMS  = ('file-io', 'dump-flats')
+VSTITCH_PARAMS     = ('file-io', 'vstitch')
+DOUBLE_FOV_PARAMS  = ('file-io', 'center', 'double-fov')
+ALL_PARAMS         = ('file-io', 'center', 'shift', 'stitch', 'bin', 'dump-flats', 'vstitch', 'double-fov')
+
+NICE_NAMES = ('General', 'File IO', 'Center', 'Shift', 'Stitch', 'Bin', 'Dump Flats', 'VStitch', 'Double FOV')
 
 def get_config_name():
     """Get the command line --config option."""

--- a/tile/config.py
+++ b/tile/config.py
@@ -74,6 +74,10 @@ SECTIONS['general'] = {
         'default': False,
         'help': 'Verbose output',
         'action': 'store_true'},
+    'show': {
+        'default': False,
+        'help': 'Show the panoramic image in a matplotlib window (requires display)',
+        'action': 'store_true'},
         }
 
 SECTIONS['file-io'] = {
@@ -101,7 +105,7 @@ SECTIONS['file-io'] = {
         'type': util.positive_int,
         'default': 0,
         'help': "Reconstruction binning factor as power(2, choice)",
-        'choices': [0, 1, 2, 3]},
+        'choices': [0, 1, 2, 3, 4]},
     'sample-x': {     
         'type': str,
         'default': '/measurement/instrument/sample_motor_stack/setup/x',
@@ -121,7 +125,11 @@ SECTIONS['file-io'] = {
     'step-x': {
         'default': 0,
         'type': float,
-        'help': 'When greater than 0, it is used to manually overide the sample x step size stored in the hdf file'},  
+        'help': 'When greater than 0, it is used to manually overide the sample x step size stored in the hdf file'},
+    'x-shifts': {
+        'default': 'None',
+        'type': str,
+        'help': "Comma-separated list of cumulative x tile shifts in pixels, e.g. [0,100,200]. 'None' = read from metadata."},
     'recon': {
         'default': 'True',
         'type': str,
@@ -129,10 +137,10 @@ SECTIONS['file-io'] = {
         }
 
 SECTIONS['stitch'] = {
-    'x-shifts': {
-        'default': 'None',
-        'type': str,
-        'help': "Projection pairs to find rotation axis. Each second projection in a pair will be flipped and used to find shifts from the first element in a pair. The shifts are used to calculate the center.  Example [0,1499] for a 180 deg scan, or [0,1499,749,2249] for 360, etc.",},            
+    'zinger-level': {
+        'default': 0.08,
+        'type': float,
+        'help': 'Zinger removal threshold: fraction above local temporal median. 0 disables.'},
     'start-proj': {
         'default': 0,
         'type': int,
@@ -141,11 +149,15 @@ SECTIONS['stitch'] = {
         'default': -1,
         'type': int,
         'help': "End projection"},   
-    'nproj-per-chunk': {     
+    'nproj-per-chunk': {
         'default': 64,
-        'type': int,        
-        'help': "Number of of projections for simultaneous processing",},    
-    }    
+        'type': int,
+        'help': "Number of of projections for simultaneous processing",},
+    'max-workers': {
+        'default': 4,
+        'type': int,
+        'help': "Number of parallel threads for chunk processing",},
+    }
 
 SECTIONS['center'] = {
     'nsino': {
@@ -168,13 +180,13 @@ SECTIONS['center'] = {
         'default': -1.0,
         'type': float,
         'help': "LLocation of rotation axis"},
-    'recon-engine': {     
+    'recon-engine': {
         'type': str,
-        'default': 'tomopy',
-        'help': "Reconstruction engine (tomopy or tomocupy). ",},    
+        'default': 'tomocupy',
+        'help': "Reconstruction engine (tomopy or tomocupy). ",},
     'reverse-grid': {
         'type': str,
-        'default': 'False',
+        'default': 'True',
         'help': 'Reverse grid datasets order',},
     'reverse-step': {
         'type': str,
@@ -187,9 +199,22 @@ SECTIONS['center'] = {
     },
     'file-type': {
         'type': str,
-        'default': 'standard',
+        'default': 'double_fov',
         'help': "Tomocupy file type: standard or double_fov",
     },
+    'nsino-per-chunk': {
+        'type': int,
+        'default': 8,
+        'help': "Number of sinograms per chunk. Use larger numbers with computers with larger memory. ",},
+    'flat-linear': {
+        'type': str,
+        'default': 'True',
+        'help': "Interpolate flat fields per projection. Assumes equal number of flats at start and end of scan.",},
+    'flats-file': {
+        'default': '',
+        'type': str,
+        'help': 'Path to HDF5 file with flat field basis frames (from dump_flats). '
+                'If set, flat correction uses a per-projection NNLS linear combination of these frames.'},
 }
 
 
@@ -202,16 +227,13 @@ SECTIONS['shift'] = {
         'type': int,
         'default': 1,
         'help': "+/- center search step (pixel). "},
-    'nsino-per-chunk': {     
-        'type': int,
-        'default': 8,
-        'help': "Number of sinograms per chunk. Use larger numbers with computers with larger memory. ",},    
     }
 
-INFO_PARAMS   = ('file-io',)
-CENTER_PARAMS = ('file-io', 'center')
-SHIFT_PARAMS  = ('file-io', 'center', 'shift')
-STITCH_PARAMS = ('file-io', 'center', 'stitch')
+INFO_PARAMS      = ('file-io',)
+CENTER_PARAMS    = ('file-io', 'center')
+SHIFT_PARAMS     = ('file-io', 'center', 'shift')
+STITCH_PARAMS    = ('file-io', 'center', 'stitch')
+PANORAMIC_PARAMS = ('file-io', 'center', 'stitch')
 ALL_PARAMS    = ('file-io', 'center', 'shift', 'stitch')
 
 NICE_NAMES = ('General', 'File IO', 'Center', 'Shift', 'Stitch')

--- a/tile/fileio.py
+++ b/tile/fileio.py
@@ -172,13 +172,14 @@ def tile(args):
     y_shift = 0
     
     tile_dict = {}
-    
+    tile_index_x_max = 0
+
     for k, v in y_sorted.items():
         if meta_dict[k][sample_x][0] > x_start:
             key = 'x' + str(tile_index_x) + 'y' + str(tile_index_y)
-            # key = [str(tile_index_x),s tr(tile_index_y)]
             log.info('%s: x = %f; y = %f, file name = %s, original file name = %s' % (key, meta_dict[k][sample_x][0], meta_dict[k][sample_y][0], k, meta_dict[k][full_file_name][0]))
             tile_index_x = tile_index_x + 1
+            tile_index_x_max = max(tile_index_x_max, tile_index_x)
             x_start = meta_dict[k][sample_x][0]
             first_y = meta_dict[k][sample_y][0]
         else:
@@ -187,12 +188,12 @@ def tile(args):
             key = 'x' + str(tile_index_x) + 'y' + str(tile_index_y)
             log.info('%s: x = %f; y = %f, file name = %s, original file name = %s' % (key, meta_dict[k][sample_x][0], meta_dict[k][sample_y][0], k, meta_dict[k][full_file_name][0]))
             tile_index_x = tile_index_x + 1
+            tile_index_x_max = max(tile_index_x_max, tile_index_x)
             x_start = y_sorted[first_key][sample_x][0] - 1
             y_shift = int((1000*(meta_dict[k][sample_y][0] - first_y)/y_sorted[first_key][resolution][0]))
 
-        tile_dict[key] = k 
+        tile_dict[key] = k
 
-    tile_index_x_max  = tile_index_x
     tile_index_y_max  = tile_index_y + 1
 
     index_list = []

--- a/tile/log.py
+++ b/tile/log.py
@@ -49,6 +49,9 @@
 '''
 import logging
 
+ACTION_LEVEL = 25
+logging.addLevelName(ACTION_LEVEL, 'ACTION')
+
 logger = logging.getLogger(__name__)
 
 def info(msg, *args, **kwargs):
@@ -62,6 +65,10 @@ def warning(msg, *args, **kwargs):
 
 def debug(msg, *args, **kwargs):
     logger.debug(msg, *args, **kwargs)
+
+def action(msg, *args, **kwargs):
+    """Log an operator action request — displayed in red in the terminal."""
+    logger.log(ACTION_LEVEL, msg, *args, **kwargs)
 
 def setup_custom_logger(lfname=None, stream_to_console=True):
 
@@ -93,6 +100,6 @@ class ColoredLogFormatter(logging.Formatter):
             record.message = self.__GREEN + record.message + self.__ENDC
         elif record.levelname == 'WARNING':
             record.message = self.__YELLOW + record.message + self.__ENDC
-        elif record.levelname == 'ERROR':
+        elif record.levelname in ('ERROR', 'ACTION'):
             record.message = self.__RED + record.message + self.__ENDC
         return super().formatMessage(record)

--- a/tile/prep.py
+++ b/tile/prep.py
@@ -1,0 +1,430 @@
+# #########################################################################
+# Copyright (c) 2022, UChicago Argonne, LLC. All rights reserved.         #
+# #########################################################################
+
+"""
+Pre- and post-processing steps for the tile mosaic pipeline:
+
+  tile bin        – spatially bin raw tile HDF5 files
+  tile dump-flats – collect flat field basis from binned files
+  tile vstitch    – vertically stitch per-row tile.h5 files
+  tile double-fov – convert 360° acquisition to 180° by stitching paired projections
+"""
+
+import glob
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import h5py
+import numpy as np
+
+from tile import log
+
+__all__ = ['bin_data', 'dump_flats', 'vstitch', 'double_fov']
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _quintic_ramp(n):
+    """Quintic blending ramp 1→0 of length n (same kernel used everywhere)."""
+    v = np.linspace(1, 0, n, endpoint=False)
+    return v**5 * (126 - 420*v + 540*v**2 - 315*v**3 + 70*v**4)
+
+
+def _bin2d(arr, factor):
+    """Average-bin the last two axes of arr by factor."""
+    n0 = arr.shape[-2] // factor * factor
+    n1 = arr.shape[-1] // factor * factor
+    a = arr[..., :n0, :n1]
+    shape = a.shape[:-2] + (n0 // factor, factor, n1 // factor, factor)
+    return a.reshape(shape).mean(axis=(-3, -1)).astype(np.float32)
+
+
+def _resolve_path(base, name):
+    """Return name as-is if absolute, else join with base."""
+    if os.path.isabs(name):
+        return name
+    return os.path.join(str(base), name)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tile bin
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _copy_item(src_item, dst_parent, bin_factor, proj_step, chunk_size=16):
+    """Recursively copy groups/datasets; bin exchange datasets."""
+    DATASETS_TO_BIN   = {'/exchange/data', '/exchange/data_white', '/exchange/data_dark'}
+    DATASETS_SUBSAMPLE = {'/exchange/data'}
+    THETA_PATH = '/exchange/theta'
+
+    name = src_item.name.split('/')[-1]
+
+    if isinstance(src_item, h5py.Group):
+        grp = dst_parent.require_group(name)
+        for k, v in src_item.attrs.items():
+            grp.attrs[k] = v
+        for child in src_item.values():
+            _copy_item(child, grp, bin_factor, proj_step, chunk_size)
+
+    elif isinstance(src_item, h5py.Dataset):
+        full_path = src_item.name
+
+        if full_path in DATASETS_TO_BIN:
+            raw_shape = src_item.shape
+            subsample = full_path in DATASETS_SUBSAMPLE
+            indices = list(range(0, raw_shape[0], proj_step)) if subsample else list(range(raw_shape[0]))
+            n_out = len(indices)
+            H_out = raw_shape[-2] // bin_factor * bin_factor // bin_factor
+            W_out = raw_shape[-1] // bin_factor * bin_factor // bin_factor
+            ds = dst_parent.create_dataset(name, shape=(n_out, H_out, W_out), dtype=np.float32,
+                                           chunks=(min(chunk_size, n_out), H_out, W_out))
+            for k, v in src_item.attrs.items():
+                ds.attrs[k] = v
+            batches = [indices[i:i+chunk_size] for i in range(0, n_out, chunk_size)]
+            out_pos = 0
+            for batch in batches:
+                chunk = src_item[list(batch)]
+                end_pos = out_pos + len(batch)
+                ds[out_pos:end_pos] = _bin2d(chunk, bin_factor)
+                out_pos = end_pos
+                log.info(f'  {name}: {out_pos}/{n_out} frames ({100*out_pos/n_out:.0f}%)')
+
+        elif full_path == THETA_PATH:
+            theta_sub = src_item[::proj_step]
+            ds = dst_parent.create_dataset(name, data=theta_sub)
+            for k, v in src_item.attrs.items():
+                ds.attrs[k] = v
+            log.info(f'  theta: {len(theta_sub)} values (every {proj_step}th)')
+
+        else:
+            dst_parent.copy(src_item, name)
+
+
+def bin_data(args):
+    """Spatially bin raw tile HDF5 files and optionally subsample projections."""
+
+    log.info('Run bin')
+    folder = str(args.folder_name)
+    bin_factor = 2 ** args.binning
+    proj_step = args.bin_step
+
+    if args.bin_output_dir:
+        dest_dir = args.bin_output_dir
+    else:
+        dest_dir = os.path.join(folder, f'bin{bin_factor}x{bin_factor}')
+
+    os.makedirs(dest_dir, exist_ok=True)
+
+    files = sorted(glob.glob(os.path.join(folder, '*.h5')))
+    if not files:
+        raise RuntimeError(f'No .h5 files found in {folder}')
+
+    log.info(f'Found {len(files)} file(s) → {dest_dir}  '
+             f'(bin={bin_factor}x{bin_factor}, proj_step={proj_step})')
+
+    for src_path in files:
+        fname = os.path.basename(src_path)
+        dst_path = os.path.join(dest_dir, fname)
+        log.info(f'[{fname}] → {dst_path}')
+        with h5py.File(src_path, 'r') as src, h5py.File(dst_path, 'w') as dst:
+            for k, v in src.attrs.items():
+                dst.attrs[k] = v
+            for item in src.values():
+                _copy_item(item, dst, bin_factor, proj_step)
+        log.info(f'  done.')
+
+    log.info('Bin complete.')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tile dump-flats
+# ─────────────────────────────────────────────────────────────────────────────
+
+def dump_flats(args):
+    """Collect flat field basis from binned tile HDF5 files.
+
+    For each input file two averaged frames are written:
+      frame 2i   – mean of first  half of data_white frames
+      frame 2i+1 – mean of second half of data_white frames
+    """
+
+    log.info('Run dump-flats')
+    folder = str(args.folder_name)
+    step = -1 if args.reverse_step == 'True' else 1
+
+    if args.y_folders:
+        yfolders = [y.strip() for y in args.y_folders.split(',')]
+        all_files = []
+        for yf in yfolders:
+            ydir = os.path.join(folder, yf)
+            files = sorted(glob.glob(os.path.join(ydir, '*.h5')))
+            if not files:
+                log.warning(f'No .h5 files in {ydir}')
+            else:
+                log.info(f'{yf}: {len(files)} file(s)')
+                all_files.extend(files)
+    else:
+        all_files = sorted(glob.glob(os.path.join(folder, '*.h5')))
+        log.info(f'Found {len(all_files)} file(s) in {folder}')
+
+    if not all_files:
+        raise RuntimeError('No HDF5 files found for dump-flats.')
+
+    with h5py.File(all_files[0], 'r') as f0:
+        flat0 = f0['/exchange/data_white'][:, :, ::step].astype('float32')
+        H, W = flat0.shape[1], flat0.shape[2]
+
+    N = len(all_files)
+    out_flats = np.zeros((2 * N, H, W), dtype='float32')
+
+    for i, fpath in enumerate(all_files):
+        with h5py.File(fpath, 'r') as fin:
+            flat = fin['/exchange/data_white'][:, :, ::step].astype('float32')
+        n = flat.shape[0]
+        out_flats[2*i]   = np.mean(flat[:n//2], axis=0)
+        out_flats[2*i+1] = np.mean(flat[n//2:], axis=0)
+        log.info(f'  [{i+1}/{N}] {os.path.relpath(fpath, folder)}  ({n} frames)')
+
+    output = _resolve_path(folder, args.dump_flats_output)
+    if os.path.exists(output):
+        os.remove(output)
+
+    with h5py.File(output, 'w') as fout:
+        fout.create_dataset('/exchange/data_white', data=out_flats, chunks=(1, H, W))
+        dt = h5py.string_dtype()
+        fout.create_dataset('file_names', data=np.array(all_files, dtype=object), dtype=dt)
+
+    log.info(f'Flat basis shape: {2*N} x {H} x {W}')
+    log.info(f'Output: {output}')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tile vstitch
+# ─────────────────────────────────────────────────────────────────────────────
+
+def vstitch(args):
+    """Vertically stitch per-row tile.h5 files into a single dataset."""
+
+    log.info('Run vstitch')
+
+    if args.y_shifts == 'None':
+        raise RuntimeError('--y-shifts is required for tile vstitch (e.g. "[0,450,450]")')
+
+    y_shifts = np.fromstring(args.y_shifts[1:-1], sep=',', dtype='int')
+    folder = str(args.folder_name)
+
+    # resolve input files
+    if args.vstitch_pattern:
+        files = sorted(glob.glob(args.vstitch_pattern))
+    elif args.y_folders:
+        yfolders = [y.strip() for y in args.y_folders.split(',')]
+        files = []
+        for yf in yfolders:
+            p = os.path.join(folder, yf, 'tile', 'tile.h5')
+            if not os.path.exists(p):
+                raise RuntimeError(f'Expected tile.h5 not found: {p}')
+            files.append(p)
+    else:
+        candidate = os.path.join(folder, 'tile', 'tile.h5')
+        if os.path.exists(candidate):
+            files = [candidate]
+        else:
+            raise RuntimeError(
+                'Cannot determine input files. Provide --y-folders, --vstitch-pattern, '
+                'or place tile.h5 under <folder-name>/tile/tile.h5.')
+
+    if len(files) != len(y_shifts):
+        raise RuntimeError(f'{len(files)} files found but {len(y_shifts)} y-shifts given.')
+
+    log.info(f'Found {len(files)} file(s):')
+    for f, ys in zip(files, y_shifts):
+        log.info(f'  y_shift={ys:4d}  {f}')
+
+    with h5py.File(files[0], 'r') as f0:
+        N_proj, H, W = f0['/exchange/data'].shape
+        theta = f0['/exchange/theta'][:]
+
+    cum = np.array([int(np.sum(y_shifts[:i+1])) for i in range(len(y_shifts))])
+    H_out = H + int(cum[-1])
+
+    log.info(f'Input  shape: {N_proj} x {H} x {W}')
+    log.info(f'Output shape: {N_proj} x {H_out} x {W}')
+
+    output = _resolve_path(folder, args.vstitch_output)
+    if os.path.exists(output):
+        os.remove(output)
+
+    nchunk = args.nproj_per_chunk
+
+    def process_chunk(st_p):
+        end_p = min(st_p + nchunk, N_proj)
+        n = end_p - st_p
+        buf = np.zeros((n, H_out, W), dtype='float32')
+        ref_overlap_mean = None
+
+        for itile, (fpath, row_st) in enumerate(zip(files, cum)):
+            row_end = row_st + H
+            ww = np.ones(H, dtype='float32')
+            if itile < len(files) - 1:
+                overlap_bot = H - y_shifts[itile + 1]
+                if overlap_bot > 0:
+                    ww[y_shifts[itile + 1]:] = _quintic_ramp(overlap_bot)
+            if itile > 0:
+                overlap_top = H - y_shifts[itile]
+                if overlap_top > 0:
+                    ww[:overlap_top] = 1.0 - _quintic_ramp(overlap_top)
+
+            with h5py.File(fpath, 'r') as fin:
+                chunk = fin['/exchange/data'][st_p:end_p].astype('float32')
+
+            # intensity scale calibration in overlap with previous tile
+            if itile > 0 and ref_overlap_mean is not None:
+                overlap_top = H - y_shifts[itile]
+                if overlap_top > 0:
+                    cur_means = np.mean(chunk[:, :overlap_top, :], axis=(1, 2))
+                    valid = cur_means > 1e-6
+                    scales = np.where(valid, ref_overlap_mean / np.where(valid, cur_means, 1.0), 1.0)
+                    chunk *= scales[:, np.newaxis, np.newaxis]
+            if itile < len(files) - 1:
+                overlap_bot = H - y_shifts[itile + 1]
+                if overlap_bot > 0:
+                    ref_overlap_mean = np.mean(chunk[:, -overlap_bot:, :], axis=(1, 2))
+
+            buf[:, row_st:row_end, :] += chunk * ww[np.newaxis, :, np.newaxis]
+
+        np.nan_to_num(buf, nan=0.0, posinf=0.0, neginf=0.0, copy=False)
+        return st_p, end_p, buf
+
+    with h5py.File(output, 'w') as fout:
+        data_out = fout.create_dataset('/exchange/data', shape=(N_proj, H_out, W),
+                                       dtype='float32', chunks=(1, H_out, W))
+        fout.create_dataset('/exchange/data_white', data=np.ones((1, H_out, W), dtype='float32'))
+        fout.create_dataset('/exchange/data_dark',  data=np.zeros((1, H_out, W), dtype='float32'))
+        fout.create_dataset('/exchange/theta', data=theta)
+
+        chunk_starts = list(range(0, N_proj, nchunk))
+        pending = {}
+        next_write = 0
+
+        with ThreadPoolExecutor(max_workers=args.max_workers) as pool:
+            futures = {pool.submit(process_chunk, st): st for st in chunk_starts}
+            for fut in as_completed(futures):
+                st_p, end_p, buf = fut.result()
+                pending[st_p] = (end_p, buf)
+                while next_write in pending:
+                    ep, b = pending.pop(next_write)
+                    log.info(f'Writing projections {next_write:4d} - {ep:4d}')
+                    data_out[next_write:ep] = b
+                    next_write = ep
+
+    log.info(f'vstitch output: {output}')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tile double-fov
+# ─────────────────────────────────────────────────────────────────────────────
+
+def double_fov(args):
+    """Convert 360° acquisition to 180° by stitching paired projections.
+
+    For each index i, stitches projection[i] with fliplr(projection[i + N//2]).
+    The rotation axis position controls the overlap/shift between the two halves.
+    """
+
+    log.info('Run double-fov')
+    folder = str(args.folder_name)
+
+    input_path  = _resolve_path(folder, args.double_fov_input)
+    output_path = _resolve_path(folder, args.double_fov_output)
+
+    if args.rotation_axis <= 0:
+        raise RuntimeError('--rotation-axis must be set for tile double-fov.')
+
+    with h5py.File(input_path, 'r') as fin:
+        N_proj, H, W = fin['/exchange/data'].shape
+        theta = fin['/exchange/theta'][:]
+
+    if N_proj % 2 != 0:
+        raise RuntimeError(f'Number of projections ({N_proj}) must be even for 360→180 conversion.')
+
+    N_half = N_proj // 2
+    cen = args.rotation_axis
+    shift_val = int(round(2 * cen)) - W + 1
+    abs_shift = abs(shift_val)
+    W_out = (W + abs_shift) // 4 * 4
+    overlap = W - abs_shift
+
+    if overlap <= 0:
+        raise RuntimeError(
+            f'No overlap between the two halves (shift={shift_val}, W={W}). '
+            f'Check --rotation-axis value.')
+
+    p0_off = 0         if shift_val >= 0 else abs_shift
+    p1_off = shift_val if shift_val >= 0 else 0
+
+    blend_p0 = _quintic_ramp(overlap)
+    blend_p1 = 1.0 - _quintic_ramp(overlap)
+
+    if shift_val >= 0:
+        ov_col_p0 = slice(W - overlap, W)
+        ov_col_p1 = slice(0, overlap)
+        out_ov    = slice(p1_off, p1_off + overlap)
+    else:
+        ov_col_p0 = slice(0, overlap)
+        ov_col_p1 = slice(W - overlap, W)
+        out_ov    = slice(p0_off, p0_off + overlap)
+
+    out_col_p0 = slice(p0_off, p0_off + W)
+    out_col_p1 = slice(p1_off, p1_off + W)
+
+    log.info(f'Input  shape : {N_proj} x {H} x {W}')
+    log.info(f'Output shape : {N_half} x {H} x {W_out}')
+    log.info(f'Rotation axis: {cen:.1f}  shift: {shift_val}  overlap: {overlap}')
+
+    nchunk = args.nproj_per_chunk
+
+    def process_chunk(st_p, end_p):
+        with h5py.File(input_path, 'r') as fin:
+            proj0 = fin['/exchange/data'][st_p:end_p].astype('float32')
+            proj1 = fin['/exchange/data'][N_half + st_p:N_half + end_p].astype('float32')
+        proj1 = proj1[:, :, ::-1]
+
+        n = end_p - st_p
+        buf = np.zeros((n, H, W + abs_shift), dtype='float32')
+        buf[:, :, out_col_p0] += proj0
+        buf[:, :, out_col_p1] += proj1
+        buf[:, :, out_ov] = (proj0[:, :, ov_col_p0] * blend_p1[np.newaxis, np.newaxis, :]
+                           + proj1[:, :, ov_col_p1] * blend_p0[np.newaxis, np.newaxis, :])
+        np.nan_to_num(buf, nan=1.0, posinf=1.0, neginf=1.0, copy=False)
+        return st_p, end_p, buf[:, :, :W_out]
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    with h5py.File(output_path, 'w') as fout:
+        data_out = fout.create_dataset('/exchange/data', shape=(N_half, H, W_out),
+                                       dtype='float32', chunks=(1, H, W_out))
+        fout.create_dataset('/exchange/data_white', data=np.ones((1, H, W_out), dtype='float32'))
+        fout.create_dataset('/exchange/data_dark',  data=np.zeros((1, H, W_out), dtype='float32'))
+        fout.create_dataset('/exchange/theta', data=theta[:N_half])
+
+        chunk_starts = list(range(0, N_half, nchunk))
+        pending = {}
+        next_write = 0
+
+        with ThreadPoolExecutor(max_workers=args.max_workers) as pool:
+            futures = {pool.submit(process_chunk, st, min(st + nchunk, N_half)): st
+                       for st in chunk_starts}
+            for fut in as_completed(futures):
+                st_p, end_p, buf = fut.result()
+                pending[st_p] = (end_p, buf)
+                while next_write in pending:
+                    ep, b = pending.pop(next_write)
+                    log.info(f'Writing projections {next_write:4d} - {ep:4d}')
+                    data_out[next_write:ep] = b
+                    next_write = ep
+
+    log.info(f'double-fov output: {output_path}')

--- a/tile/shift.py
+++ b/tile/shift.py
@@ -56,6 +56,19 @@ __all__ = ['shift_manual',
           ]
 
 
+def _next_smooth(n):
+    """Return the smallest integer >= n whose prime factors are all in {2, 3, 5}."""
+    candidate = n
+    while True:
+        m = candidate
+        for p in (2, 3, 5):
+            while m % p == 0:
+                m //= p
+        if m == 1:
+            return candidate
+        candidate += 1
+
+
 def center(args):
     """Find rotation axis location"""
 
@@ -84,8 +97,10 @@ def center(args):
     idslice = int((data_shape[1]-1)*args.nsino)
     idproj = int((data_shape[0]-1)*args.nprojection)
 
-    # data size after stitching
-    size = int(np.ceil((data_shape[2]+(grid.shape[1]-1)*x_shift)/2**(args.binning+4))*2**(args.binning+4))
+    # data size after stitching, rounded up to a cuFFT-friendly number
+    # (product of small primes 2,3,5 only, so FFT size 4*size avoids prime factors > 5)
+    raw_size = data_shape[2] + (grid.shape[1]-1)*x_shift
+    size = _next_smooth(raw_size)
     data_all = np.ones([data_shape[0],2**args.binning,size],dtype=data_type)
     dark_all = np.zeros([1,2**args.binning,size],dtype=data_type)
     flat_all = np.ones([1,2**args.binning,size],dtype=data_type)

--- a/tile/shift.py
+++ b/tile/shift.py
@@ -125,7 +125,7 @@ def center(args):
     log.info(f'Created a temporary hdf file: {tmp_file_name}')
     cmd = f'{args.recon_engine} recon --file-type double_fov --binning {args.binning} --reconstruction-type try --file-name {tmp_file_name} \
             --center-search-width {args.center_search_width} --rotation-axis-auto manual --rotation-axis {args.rotation_axis} \
-            --center-search-step {args.center_search_step} --end-column {args.end_column} --nsino-per-chunk 2'
+            --center-search-step {args.center_search_step} --end-column {args.end_column} --nsino-per-chunk {2**args.binning}'
     log.warning(cmd)
     os.system(cmd)      
     

--- a/tile/shift.py
+++ b/tile/shift.py
@@ -56,6 +56,7 @@ __all__ = ['shift_manual',
           ]
 
 
+
 def _next_smooth(n):
     """Return the smallest integer >= n whose prime factors are all in {2, 3, 5}."""
     candidate = n
@@ -97,41 +98,93 @@ def center(args):
     idslice = int((data_shape[1]-1)*args.nsino)
     idproj = int((data_shape[0]-1)*args.nprojection)
 
+    # resolve x_shifts: use provided list or fall back to uniform nominal x_shift
+    if args.x_shifts != 'None':
+        x_shifts = np.fromstring(args.x_shifts[1:-1], sep=',', dtype='int')
+        log.info(f'Using provided x-shifts: {x_shifts}')
+    else:
+        x_shifts = np.zeros(grid.shape[1], dtype='int')
+        x_shifts[1:] = x_shift
+        log.info(f'Using nominal x-shifts: {x_shifts}')
+
     # data size after stitching, rounded up to a cuFFT-friendly number
-    # (product of small primes 2,3,5 only, so FFT size 4*size avoids prime factors > 5)
-    raw_size = data_shape[2] + (grid.shape[1]-1)*x_shift
+    raw_size = data_shape[2] + int(np.sum(x_shifts))
     size = _next_smooth(raw_size)
+    # load external flat field basis if provided
+    use_flats_basis = bool(args.flats_file)
+    if use_flats_basis:
+        import h5py
+        with h5py.File(args.flats_file, 'r') as fb:
+            basis_flats = fb['/exchange/data_white'][:, idslice:idslice+2**args.binning, ::step].astype('float32')
+        log.info(f'Loaded flat basis: {basis_flats.shape[0]} frames from {args.flats_file}')
+        basis_profs = np.mean(basis_flats, axis=2).T.astype('float64')  # (binning, n_basis)
+
+    # pre-compute per-tile flat/dark correction arrays
+    tile_dark = []
+    tile_flat_p0 = []
+    tile_flat_p1 = []
+    for itile in range(grid.shape[1]):
+        if args.reverse_grid=='True':
+            iitile=grid.shape[1]-itile-1
+        else:
+            iitile=itile
+        _,flat,dark,_ = dxchange.read_aps_tomoscan_hdf5(grid[0,::-step][iitile],sino=(idslice,idslice+2**args.binning))
+        n = flat.shape[0]
+        tile_dark.append(np.mean(dark[:,:,::step], axis=0))
+        tile_flat_p0.append(np.mean(flat[:n//2,:,::step], axis=0))
+        tile_flat_p1.append(np.mean(flat[n//2:,:,::step], axis=0))
+
     data_all = np.ones([data_shape[0],2**args.binning,size],dtype=data_type)
-    dark_all = np.zeros([1,2**args.binning,size],dtype=data_type)
+    print(data_all.shape)
     flat_all = np.ones([1,2**args.binning,size],dtype=data_type)
+    dark_all = np.zeros([1,2**args.binning,size],dtype=data_type)
 
     tmp_file_name = f'{args.folder_name}{args.tmp_file_name}'
     dirPath = os.path.dirname(tmp_file_name)
     if not os.path.exists(dirPath):
         os.makedirs(dirPath)
 
-    # Center search with using the first tile
     for itile in range(grid.shape[1]):
+        print(itile)
         if args.reverse_grid=='True':
             iitile=grid.shape[1]-itile-1
-        else: 
+        else:
             iitile=itile
-        data,flat,dark,theta = dxchange.read_aps_tomoscan_hdf5(grid[0,::-step][iitile],sino=(idslice,idslice+2**args.binning))       
-        v = np.linspace(1, 0, data_shape[2]-x_shift, endpoint=False)
-        v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)
+        data,_,_,theta = dxchange.read_aps_tomoscan_hdf5(grid[0,::-step][iitile],sino=(idslice,idslice+2**args.binning))
+        st = int(np.sum(x_shifts[:itile+1]))
+        end = st+data_shape[2]
         vv = np.ones(data_shape[2])
         if itile<grid.shape[1]-1:
-            vv[x_shift:]=v
+            overlap_r = data_shape[2]-x_shifts[itile+1]
+            v = np.linspace(1, 0, overlap_r, endpoint=False)
+            v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)
+            vv[x_shifts[itile+1]:]=v
         if itile>0:
-            vv[:data_shape[2]-x_shift]=1-v
-
-        st = itile*x_shift
-        end = st+data_shape[2]
-        data_all[:data.shape[0],:,st:end] += data[:,:,::step]*vv
-        data_all[data.shape[0]:,:,st:end] += data[-1,:,::step]*vv
-        dark_all[:,:,st:end] += np.mean(dark[:,:,::step],axis=0)*vv
-        flat_all[:,:,st:end] += np.mean(flat[:,:,::step],axis=0)*vv
-        f = dx.File(tmp_file_name, mode='w') 
+            overlap_l = data_shape[2]-x_shifts[itile]
+            v = np.linspace(1, 0, overlap_l, endpoint=False)
+            v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)
+            vv[:overlap_l]=1-v
+        dark_mean = tile_dark[itile]
+        data_f = data[:,:,::step].copy()
+        if use_flats_basis:
+            from scipy.optimize import nnls
+            for i in range(data_f.shape[0]):
+                proj_prof = np.mean(data_f[i], axis=1).astype('float64')
+                w, _ = nnls(basis_profs, proj_prof)
+                flat_i = np.einsum('k,khw->hw', w, basis_flats)
+                data_f[i] = (data_f[i] - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+        elif args.flat_linear == 'True':
+            for i in range(data_f.shape[0]):
+                t = i / max(data_shape[0]-1, 1)
+                flat_i = (1-t)*tile_flat_p0[itile] + t*tile_flat_p1[itile]
+                data_f[i] = (data_f[i] - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+        else:
+            flat_mean = (tile_flat_p0[itile] + tile_flat_p1[itile]) / 2
+            data_f = (data_f - dark_mean) / np.maximum(flat_mean - dark_mean, 1e-3)
+        np.nan_to_num(data_f, nan=1.0, posinf=1.0, neginf=1.0, copy=False)
+        data_all[:data_f.shape[0],:,st:end] += data_f*vv
+        data_all[data_f.shape[0]:,:,st:end] += data_f[-1]*vv
+        f = dx.File(tmp_file_name, mode='w')
         f.add_entry(dx.Entry.data(data={'value': data_all, 'units':'counts'}))
         f.add_entry(dx.Entry.data(data_white={'value': flat_all, 'units':'counts'}))
         f.add_entry(dx.Entry.data(data_dark={'value': dark_all, 'units':'counts'}))
@@ -140,12 +193,109 @@ def center(args):
     log.info(f'Created a temporary hdf file: {tmp_file_name}')
     cmd = f'{args.recon_engine} recon --file-type {args.file_type} --binning {args.binning} --reconstruction-type try --file-name {tmp_file_name} \
             --center-search-width {args.center_search_width} --rotation-axis-auto manual --rotation-axis {args.rotation_axis} \
-            --center-search-step {args.center_search_step} --end-column {args.end_column} --nsino-per-chunk {2**args.binning}'
+            --center-search-step {args.center_search_step} --end-column {args.end_column} --nsino-per-chunk {args.nsino_per_chunk}'
     log.warning(cmd)
     os.system(cmd)      
     
     try_path = f"{os.path.dirname(tmp_file_name)}_rec/try_center/tmp/recon*"
-    log.info(f'Please open the stack of images from {try_path} and select the rotation center')
+    log.action(f'Please open the stack of images from {try_path} and select the rotation center')
+
+
+def panoramic(args):
+    """Stitch a single projection from all tiles and save as a tiff for quick inspection.
+    Uses nominal overlap from hdf metadata by default, or --x-shifts if provided."""
+
+    import tifffile
+
+    log.info('Run panoramic stitching')
+    meta_dict, grid, data_shape, data_type, x_shift, y_shift = fileio.tile(args)
+    log.info('image   size (x, y) in pixels: (%d, %d)' % (data_shape[2], data_shape[1]))
+    log.info('stitch shift (x, y) in pixels: (%d, %d)' % (x_shift, y_shift))
+    log.info('tile overlap (x, y) in pixels: (%d, %d)' % (data_shape[2]-x_shift, data_shape[1]-y_shift))
+
+    if args.reverse_step == 'True':
+        step = -1
+    else:
+        step = 1
+
+    # build x_shifts array: use provided --x-shifts or nominal overlap
+    if args.x_shifts != 'None':
+        x_shifts = np.fromstring(args.x_shifts[1:-1], sep=',', dtype='int')
+        log.info(f'Using provided x-shifts: {x_shifts}')
+    else:
+        x_shifts = np.zeros(grid.shape[1], dtype='int')
+        x_shifts[1:] = x_shift
+        log.info(f'Using nominal x-shifts: {x_shifts}')
+
+    size = int(data_shape[2] + np.sum(x_shifts))
+    idproj = int((data_shape[0]-1)*args.nprojection)
+    log.info(f'Stitching projection {idproj} of {data_shape[0]}')
+
+    use_flats_basis = bool(args.flats_file)
+    if use_flats_basis:
+        import h5py
+        with h5py.File(args.flats_file, 'r') as fb:
+            basis_flats = fb['/exchange/data_white'][:, :, ::step].astype('float32')
+        log.info(f'Loaded flat basis: {basis_flats.shape[0]} frames from {args.flats_file}')
+        basis_profs = np.mean(basis_flats, axis=2).T.astype('float64')
+
+    pano = np.zeros([data_shape[1], size], dtype='float32')
+
+    for itile in range(grid.shape[1]):
+        if args.reverse_grid == 'True':
+            iitile = grid.shape[1]-itile-1
+        else:
+            iitile = itile
+
+        data, flat, dark, _ = dxchange.read_aps_tomoscan_hdf5(
+            grid[0, ::-step][iitile], proj=(idproj, idproj+1))
+        dark_mean = np.mean(dark, axis=0)
+        n = flat.shape[0]
+        p0 = np.mean(flat[:n//2, :, ::step], axis=0)
+        p1 = np.mean(flat[n//2:, :, ::step], axis=0)
+        if use_flats_basis:
+            from scipy.optimize import nnls
+            data_f = data[0, :, ::step]
+            proj_prof = np.mean(data_f, axis=1).astype('float64')
+            w, _ = nnls(basis_profs, proj_prof)
+            flat_i = np.einsum('k,khw->hw', w, basis_flats)
+            proj = (data_f - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+        elif args.flat_linear == 'True':
+            t = idproj / max(data_shape[0]-1, 1)
+            flat_i = (1-t)*p0 + t*p1
+            proj = (data[0, :, ::step] - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+        else:
+            flat_mean = (p0 + p1) / 2
+            proj = (data[0, :, ::step] - dark_mean) / np.maximum(flat_mean - dark_mean, 1e-3)
+
+        v = np.linspace(1, 0, data_shape[2]-x_shift, endpoint=False)
+        v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)
+        vv = np.ones(data_shape[2])
+        if itile < grid.shape[1]-1:
+            vv[x_shift:] = v
+        if itile > 0:
+            vv[:data_shape[2]-x_shift] = 1-v
+
+        st = int(np.sum(x_shifts[:itile+1]))
+        end = min(st+data_shape[2], size)
+        pano[:, st:end] += proj[:, :end-st]*vv[:end-st]
+
+    out_dir = os.path.join(args.folder_name, 'tile')
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    out_path = os.path.join(out_dir, 'panoramic.tif')
+    tifffile.imwrite(out_path, pano)
+    log.info(f'Saved panoramic projection to {out_path}')
+
+    if args.show:
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots(figsize=(16, 4))
+        p_low, p_high = np.percentile(pano, [1, 99])
+        ax.imshow(pano, cmap='gray', vmin=p_low, vmax=p_high, aspect='auto')
+        ax.set_title('Panoramic projection (nominal overlap)')
+        ax.axis('off')
+        plt.tight_layout()
+        plt.show()
 
 
 def shift_manual(args):
@@ -178,33 +328,69 @@ def shift_manual(args):
     dark_all = np.zeros([1,2**args.binning,size],dtype=data_type)
     flat_all = np.ones([1,2**args.binning,size],dtype=data_type)
 
+    # load external flat field basis if provided
+    use_flats_basis = bool(args.flats_file)
+    if use_flats_basis:
+        import h5py
+        with h5py.File(args.flats_file, 'r') as fb:
+            basis_flats = fb['/exchange/data_white'][:, :, ::step].astype('float32')
+        log.info(f'Loaded flat basis: {basis_flats.shape[0]} frames from {args.flats_file}')
+        basis_profs = np.mean(basis_flats, axis=2).T.astype('float64')
+        basis_flats_sino = basis_flats[:, idslice:idslice+2**args.binning, :]
+        basis_profs_sino = np.mean(basis_flats_sino, axis=2).T.astype('float64')
+
+    # pre-compute per-tile flat/dark correction arrays
+    tile_dark = []
+    tile_flat_p0 = []
+    tile_flat_p1 = []
+    for itile in range(grid.shape[1]):
+        if args.reverse_grid=='True':
+            iitile=grid.shape[1]-itile-1
+        else:
+            iitile=itile
+        _,flat,dark,_ = dxchange.read_aps_tomoscan_hdf5(grid[0,::-step][iitile],sino=(idslice,idslice+2**args.binning))
+        n = flat.shape[0]
+        tile_dark.append(np.mean(dark[:,:,::step], axis=0))
+        tile_flat_p0.append(np.mean(flat[:n//2,:,::step], axis=0))
+        tile_flat_p1.append(np.mean(flat[n//2:,:,::step], axis=0))
+
     tmp_file_name = f'{args.folder_name}/tile/tmp.h5'
     dirPath = os.path.dirname(tmp_file_name)
     if not os.path.exists(dirPath):
         os.makedirs(dirPath)
     center = input(f"Please enter rotation center ({args.rotation_axis}): ")
-    if center is not None:        
-        args.rotation_axis = center
+    if center.strip():
+        args.rotation_axis = center.strip()
     # find shift error
-    arr_err = range(-args.shift_search_width,args.shift_search_width,args.shift_search_step)
+    arr_err = range(-args.shift_search_width, args.shift_search_width, args.shift_search_step)
     data_all = np.ones([data_shape[0],2**args.binning*len(arr_err),size],dtype=data_type)
     dark_all = np.zeros([1,2**args.binning*len(arr_err),size],dtype=data_type)
     flat_all = np.ones([1,2**args.binning*len(arr_err),size],dtype=data_type)    
-    print(data_all.shape)
-    
     pdata_all = np.ones([len(arr_err),data_shape[1],size],dtype='float32')
-    x_shifts_res = np.zeros(grid.shape[1],'int')
-    x_shifts_res[1:] = x_shift
-    for jtile in range(1,grid.shape[1]):      
-        
-        print(jtile)  
+    if args.x_shifts != 'None':
+        x_shifts_res = np.fromstring(args.x_shifts[1:-1], sep=',', dtype='int')
+        log.info(f'Using provided x-shifts: {x_shifts_res}')
+    else:
+        x_shifts_res = np.zeros(grid.shape[1],'int')
+        x_shifts_res[1:] = x_shift
+        log.info(f'Using nominal x-shifts: {x_shifts_res}')
+
+
+    for jtile in range(1,grid.shape[1]):
+
+        log.info(f'Processing tile boundary {jtile} of {grid.shape[1]-1}')
         data_all[:]  = 1
         flat_all[:]  = 1
         dark_all[:]  = 0
         pdata_all[:] = 1
-        
+
+        n_shifts = len(arr_err)
         for ishift,err_shift in enumerate(arr_err):
-            print(ishift)                
+            pct = (ishift + 1) / n_shifts
+            filled = int(40 * pct)
+            bar = '\u2588' * filled + '\u2591' * (40 - filled)
+            print(f'\r  [{bar}] {ishift+1}/{n_shifts} ({err_shift:+d} px)', end='', flush=True)
+
             x_shifts = x_shifts_res.copy()
             x_shifts[jtile] += err_shift
             for itile in range(grid.shape[1]):
@@ -228,45 +414,90 @@ def shift_manual(args):
                 if args.recon=='True':
                     sts = ishift*2**args.binning
                     ends = sts+2**args.binning
-                    # data_all[:,sts:ends,st:end] = data[:,:,::step][:,:,:end-st]*vv[:end-st]
-                    data_all[:data.shape[0],sts:ends,st:end] += data[:,:,::step][:,:,:end-st]*vv[:end-st]
-                    data_all[data.shape[0]:,sts:ends,st:end] += data[-1,:,::step][:,:end-st]*vv[:end-st]
-                    dark_all[:,sts:ends,st:end] += np.mean(dark[:,:,::step],axis=0)[:,:end-st]*vv[:end-st]
-                    flat_all[:,sts:ends,st:end] += np.mean(flat[:,:,::step],axis=0)[:,:end-st]*vv[:end-st]
-                data,flat,dark,theta = dxchange.read_aps_tomoscan_hdf5(grid[0,::-step][iitile],proj=(idproj,idproj+1))       
-                data = (data-np.mean(dark,axis=0))/np.maximum(1e-3,(np.mean(flat,axis=0)-np.mean(dark,axis=0)))
-                pdata_all[ishift,:,st:end] += data[0,:,::step][:,:end-st]*vv[:end-st]
+                    dark_mean = tile_dark[itile]
+                    data_f = data[:,:,::step].copy()
+                    if use_flats_basis:
+                        from scipy.optimize import nnls
+                        for i in range(data_f.shape[0]):
+                            proj_prof = np.mean(data_f[i], axis=1).astype('float64')
+                            w, _ = nnls(basis_profs_sino, proj_prof)
+                            flat_i = np.einsum('k,khw->hw', w, basis_flats_sino)
+                            data_f[i] = (data_f[i] - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+                    elif args.flat_linear == 'True':
+                        for i in range(data_f.shape[0]):
+                            t = i / max(data_shape[0]-1, 1)
+                            flat_i = (1-t)*tile_flat_p0[itile] + t*tile_flat_p1[itile]
+                            data_f[i] = (data_f[i] - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+                    else:
+                        flat_mean = (tile_flat_p0[itile] + tile_flat_p1[itile]) / 2
+                        data_f = (data_f - dark_mean) / np.maximum(flat_mean - dark_mean, 1e-3)
+                    np.nan_to_num(data_f, nan=1.0, posinf=1.0, neginf=1.0, copy=False)
+                    data_all[:data_f.shape[0],sts:ends,st:end] += data_f[:,:,:end-st]*vv[:end-st]
+                    data_all[data_f.shape[0]:,sts:ends,st:end] += data_f[-1,:,:end-st]*vv[:end-st]
+                data,flat,dark,theta = dxchange.read_aps_tomoscan_hdf5(grid[0,::-step][iitile],proj=(idproj,idproj+1))
+                dark_mean = np.mean(dark,axis=0)
+                n = flat.shape[0]
+                p0 = np.mean(flat[:n//2,:,::step], axis=0)
+                p1 = np.mean(flat[n//2:,:,::step], axis=0)
+                if use_flats_basis:
+                    from scipy.optimize import nnls
+                    data_f = data[0,:,::step]
+                    proj_prof = np.mean(data_f, axis=1).astype('float64')
+                    w, _ = nnls(basis_profs, proj_prof)
+                    flat_i = np.einsum('k,khw->hw', w, basis_flats)
+                    data = (data_f - dark_mean) / np.maximum(flat_i - dark_mean, 1e-3)
+                elif args.flat_linear == 'True':
+                    t = idproj / max(data_shape[0]-1, 1)
+                    flat_i = (1-t)*p0 + t*p1
+                    data = (data[0,:,::step]-dark_mean)/np.maximum(1e-3,(flat_i-dark_mean))
+                else:
+                    flat_mean = (p0 + p1) / 2
+                    data = (data[0,:,::step]-dark_mean)/np.maximum(1e-3,(flat_mean-dark_mean))
+                pdata_all[ishift,:,st:end] = data[:,:end-st]#*vv[:end-st]
                 if itile==grid.shape[1]-1:
-                    data_all[:,sts:ends,end:]=data_all[:,sts:ends,end-1:end]
-                    dark_all[:,sts:ends,end:]=dark_all[:,sts:ends,end-1:end]
-                    flat_all[:,sts:ends,end:]=flat_all[:,sts:ends,end-1:end]
+                    if args.recon=='True':
+                        data_all[:,sts:ends,end:]=data_all[:,sts:ends,end-1:end]
                     pdata_all[ishift,:,end:]=pdata_all[ishift,:,end-1:end]
+        print()  # end progress bar line
         # create a temporarily DataExchange file
         dir = os.path.dirname(tmp_file_name)
         basename = os.path.basename(tmp_file_name)
         if not os.path.exists(dirPath):
             os.makedirs(dirPath)
-        dxchange.write_tiff_stack(pdata_all,f'{dir}_rec/{basename[:-3]}_proj/p',overwrite=True)        
+        dxchange.write_tiff_stack(pdata_all,f'{dir}_rec/{basename[:-3]}_proj/p',overwrite=True)
+
+
         #if args.recon==True:
-        f = dx.File(tmp_file_name, mode='w') 
-        print(data_all.shape)
+        f = dx.File(tmp_file_name, mode='w')
         f.add_entry(dx.Entry.data(data={'value': data_all, 'units':'counts'}))
         f.add_entry(dx.Entry.data(data_white={'value': flat_all, 'units':'counts'}))
         f.add_entry(dx.Entry.data(data_dark={'value': dark_all, 'units':'counts'}))
         f.add_entry(dx.Entry.data(theta={'value': theta*180/np.pi, 'units':'degrees'}))
-        f.close()        
-        
-        cmd = f'{args.recon_engine} recon --file-type double_fov --binning {args.binning} --reconstruction-type full \
+        f.close()
+
+        cmd = f'{args.recon_engine} recon --file-type {args.file_type} --binning {args.binning} --reconstruction-type full \
         --file-name {tmp_file_name} --rotation-axis-auto manual --rotation-axis {args.rotation_axis} --nsino-per-chunk {args.nsino_per_chunk} --end-column {args.end_column}'
         log.warning(cmd)
-        os.system(cmd)   
-        
+        os.system(cmd)
+
+
         try_path = f"{os.path.dirname(tmp_file_name)}_rec/tmp_rec/recon*"
         tryproj_path = f"{dir}_rec/{basename[:-3]}_proj/p*"
-        print(f'Please open the stack of images from reconstructions {try_path} or stitched projections {tryproj_path}, and select the file id to shift tile {jtile}')
-        sh = int(input(f"Please enter id for tile {jtile}: "))
-        
+        _G = "\033[92m"; _R = "\033[91m"; _Y = "\033[33m"; _E = "\033[0m"
+        parts = [f'{(_G if e<0 else _R if e==0 else _Y)}{i}={e:+d}px{_E}' for i, e in enumerate(arr_err)]
+        print(f'Index-to-pixel-offset map for tile {jtile}: ' + ', '.join(parts))
+        log.action(f'Please open the stack of images from reconstructions {try_path} or stitched projections {tryproj_path}, and select the file id to shift tile {jtile}')
+        nominal_idx = list(arr_err).index(0)
+        nominal_overlap = data_shape[2] - x_shift
+        sh_str = input(
+            f"Please enter id for tile {jtile} shift "
+            f"[nominal: {nominal_idx}] corresponding to 0 pixel shift "
+            f"from the nominal overlap of {nominal_overlap} px stored in the raw data files: "
+        )
+        sh = int(sh_str.strip()) if sh_str.strip() else nominal_idx
+
         x_shifts_res[jtile]+=arr_err[sh]
+        log.info(f'Selected offset for tile {jtile}: {arr_err[sh]:+d} px from nominal (index {sh})')
         log.info(f'Current shifts: {x_shifts_res}')
         
 

--- a/tile/shift.py
+++ b/tile/shift.py
@@ -79,7 +79,7 @@ def center(args):
         step=1    
     if args.rotation_axis==-1:
         args.rotation_axis = data_shape[2]//2
-        log.warning('Rotation in pixel: (%d)' % (rotation_axis))
+        log.warning('Rotation in pixel: (%d)' % (args.rotation_axis))
     # ids for slice and projection for shifts testing
     idslice = int((data_shape[1]-1)*args.nsino)
     idproj = int((data_shape[0]-1)*args.nprojection)

--- a/tile/shift.py
+++ b/tile/shift.py
@@ -138,7 +138,7 @@ def center(args):
         f.add_entry(dx.Entry.data(theta={'value': theta*180/np.pi, 'units':'degrees'}))
         f.close()
     log.info(f'Created a temporary hdf file: {tmp_file_name}')
-    cmd = f'{args.recon_engine} recon --file-type double_fov --binning {args.binning} --reconstruction-type try --file-name {tmp_file_name} \
+    cmd = f'{args.recon_engine} recon --file-type {args.file_type} --binning {args.binning} --reconstruction-type try --file-name {tmp_file_name} \
             --center-search-width {args.center_search_width} --rotation-axis-auto manual --rotation-axis {args.rotation_axis} \
             --center-search-step {args.center_search_step} --end-column {args.end_column} --nsino-per-chunk {2**args.binning}'
     log.warning(cmd)

--- a/tile/stitch.py
+++ b/tile/stitch.py
@@ -47,6 +47,7 @@ import os
 import h5py
 import dxchange
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from tile import log
 from tile import fileio
@@ -110,81 +111,143 @@ def stitching(args):
             if(len(fid['/exchange/theta'][:])>len(theta)):
                 theta = fid['/exchange/theta'][:]
 
+    # load external flat field basis if provided
+    use_flats_basis = bool(args.flats_file)
+    if use_flats_basis:
+        with h5py.File(args.flats_file, 'r') as fb:
+            basis_flats = fb['/exchange/data_white'][:, :, ::step].astype('float32')
+        log.info(f'Loaded flat basis: {basis_flats.shape[0]} frames from {args.flats_file}')
+        # design matrix: mean horizontal profile of each basis frame, shape (H, n_basis)
+        basis_profs = np.mean(basis_flats, axis=2).T.astype('float64')  # (H, n_basis)
+
+    # pre-compute per-tile flat/dark correction arrays (read once, reused for all chunks)
+    tile_dark = []
+    if args.flat_linear == 'True':
+        tile_flat_p0 = []
+        tile_flat_p1 = []
+    else:
+        tile_flat = []
+
+    for itile in range(grid.shape[1]):
+        if args.reverse_grid=='True':
+            iitile=grid.shape[1]-itile-1
+        else:
+            iitile=itile
+        with h5py.File(grid[0, ::-step][iitile],'r') as fidin:
+            flat = fidin['/exchange/data_white'][:]
+            dark = fidin['/exchange/data_dark'][:]
+        tile_dark.append(np.mean(dark[:, :, ::step], axis=0))
+        if args.flat_linear == 'True':
+            n = flat.shape[0]
+            tile_flat_p0.append(np.mean(flat[:n//2, :, ::step], axis=0))
+            tile_flat_p1.append(np.mean(flat[n//2:, :, ::step], axis=0))
+        else:
+            tile_flat.append(np.mean(flat[:, :, ::step], axis=0))
+
     os.system(f'rm -rf {tile_file_name}')
     with h5py.File(tile_file_name, 'w') as fid:
-        # init output arrays
+        # flat/dark correction applied per tile before stitching; store 1 and 0 as placeholders
         data_all = fid.create_dataset('/exchange/data', (args.end_proj-args.start_proj,
                                       data_shape[1], size), dtype=data_type, chunks=(1, data_shape[1], size))
-        flat_all = fid.create_dataset(
-            '/exchange/data_white', (1, data_shape[1], size), dtype=data_type, chunks=(1, data_shape[1], size))
-        dark_all = fid.create_dataset(
-            '/exchange/data_dark', (1, data_shape[1], size), dtype=data_type, chunks=(1, data_shape[1], size))
-        theta = fid.create_dataset(
-            '/exchange/theta', data=theta[args.start_proj:args.end_proj])
+        fid.create_dataset('/exchange/data_white',
+                           data=np.ones((1, data_shape[1], size), dtype=data_type))
+        fid.create_dataset('/exchange/data_dark',
+                           data=np.zeros((1, data_shape[1], size), dtype=data_type))
+        fid.create_dataset('/exchange/theta', data=theta[args.start_proj:args.end_proj])
         write_meta(grid[0, itile],fid)
 
-        for itile in range(grid.shape[1]):
-                
-            if args.reverse_grid=='True':
-                iitile=grid.shape[1]-itile-1
-            else: 
-                iitile=itile
-            with h5py.File(grid[0, ::-step][iitile],'r') as fidin:
-                flat = fidin['/exchange/data_white'][:]
-                dark = fidin['/exchange/data_dark'][:]
-                
-                st = np.sum(x_shifts[:itile+1])
-                end = min(st+data_shape[2], size)
-                vv = np.ones(data_shape[2])
-                if itile<grid.shape[1]-1:
-                    v = np.linspace(1, 0, data_shape[2]-x_shifts[itile+1], endpoint=False)
-                    v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)                    
-                    vv[x_shifts[itile+1]:]=v
-                if itile>0:
-                    v = np.linspace(1, 0, data_shape[2]-x_shifts[itile], endpoint=False)
-                    v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)                    
-                    vv[:data_shape[2]-x_shifts[itile]]=1-v
-                dark_all[0,:, st:end] += np.mean(dark[:, :, ::step],axis=0)*vv[:end-st]
-                flat_all[0,:, st:end] += np.mean(flat[:, :, ::step],axis=0)*vv[:end-st]
-            if itile==grid.shape[1]-1:
-                dark_all[0,:,end:]=dark_all[0,:,end-1:end]
-                flat_all[0,:,end:]=flat_all[0,:,end-1:end]
-
-        for ichunk in range(int(np.ceil((args.end_proj-args.start_proj)/args.nproj_per_chunk))):
-            # processing by chunks in angles
-            st_chunk = args.start_proj+ichunk*args.nproj_per_chunk
-            end_chunk = min(st_chunk+args.nproj_per_chunk, args.end_proj)
+        def process_chunk(ichunk):
+            st_chunk = args.start_proj + ichunk * args.nproj_per_chunk
+            end_chunk = min(st_chunk + args.nproj_per_chunk, args.end_proj)
+            chunk_len = end_chunk - st_chunk
 
             log.info(f'Stitching projections {st_chunk} - {end_chunk}')
+            chunk_buf = np.zeros((chunk_len, data_shape[1], size), dtype=data_type)
+            ref_overlap_mean = None
             for itile in range(grid.shape[1]):
-                
-                if args.reverse_grid=='True':
-                    iitile=grid.shape[1]-itile-1
-                else: 
-                    iitile=itile
-                with h5py.File(grid[0, ::-step][iitile],'r') as fidin:
+
+                if args.reverse_grid == 'True':
+                    iitile = grid.shape[1] - itile - 1
+                else:
+                    iitile = itile
+                with h5py.File(grid[0, ::-step][iitile], 'r') as fidin:
                     uids = fidin['/defaults/NDArrayUniqueId'][:]
-                    hdf_location = fidin['/defaults/HDF5FrameLocation']                        
-                    proj_ids = uids[hdf_location[:] == b'/exchange/data']-1
-                    proj_ids = proj_ids[(proj_ids>=st_chunk)*(proj_ids<end_chunk)]
-                    if len(proj_ids)!=end_chunk-st_chunk:
+                    hdf_location = fidin['/defaults/HDF5FrameLocation']
+                    proj_ids = uids[hdf_location[:] == b'/exchange/data'] - 1
+                    proj_ids = proj_ids[(proj_ids >= st_chunk) * (proj_ids < end_chunk)]
+                    if len(proj_ids) != end_chunk - st_chunk:
                         log.warning('There are missing projection in the current tile, setting them to 0')
                     data = fidin['/exchange/data'][proj_ids]
-                    
-                    st = np.sum(x_shifts[:itile+1])
-                    end = min(st+data_shape[2], size)
+
+                    st = np.sum(x_shifts[:itile + 1])
+                    end = min(st + data_shape[2], size)
                     vv = np.ones(data_shape[2])
-                    if itile<grid.shape[1]-1:
-                        v = np.linspace(1, 0, data_shape[2]-x_shifts[itile+1], endpoint=False)
-                        v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)                    
-                        vv[x_shifts[itile+1]:]=v
-                    if itile>0:
-                        v = np.linspace(1, 0, data_shape[2]-x_shifts[itile], endpoint=False)
-                        v = v**5*(126-420*v+540*v**2-315*v**3+70*v**4)                    
-                        vv[:data_shape[2]-x_shifts[itile]]=1-v
-                    data_all[proj_ids-args.start_proj, :, st:end] += data[:, :, ::step]*vv[:end-st]
-                if itile==grid.shape[1]-1:
-                    data_all[proj_ids-args.start_proj,:,end:]=np.tile(data_all[proj_ids-args.start_proj,:,end-1:end],(1,1,size-end))
+                    if itile < grid.shape[1] - 1:
+                        v = np.linspace(1, 0, data_shape[2] - x_shifts[itile + 1], endpoint=False)
+                        v = v**5 * (126 - 420*v + 540*v**2 - 315*v**3 + 70*v**4)
+                        vv[x_shifts[itile + 1]:] = v
+                    if itile > 0:
+                        v = np.linspace(1, 0, data_shape[2] - x_shifts[itile], endpoint=False)
+                        v = v**5 * (126 - 420*v + 540*v**2 - 315*v**3 + 70*v**4)
+                        vv[:data_shape[2] - x_shifts[itile]] = 1 - v
+
+                    # correct each tile before stitching using that tile's flat/dark
+                    data_f = data[:, :, ::step].copy()
+                    dark_mean = tile_dark[itile]
+                    if use_flats_basis:
+                        from scipy.optimize import nnls 
+                        for li in range(len(proj_ids)):
+                            proj_prof = np.mean(data_f[li], axis=1).astype('float64')
+                            w, _ = nnls(basis_profs, proj_prof)
+                            #log.info(f'proj {proj_ids[li]:4d} tile {itile} coeffs: {np.round(w, 4).tolist()}')
+                            flat_i = np.einsum('k,khw->hw', w, basis_flats)
+                            data_f[li] = (data_f[li] - dark_mean) / (flat_i - dark_mean+1e-3)
+                    elif args.flat_linear == 'True':
+                        for li, gi in enumerate(proj_ids):
+                            t = gi / max(data_shape[0] - 1, 1)
+                            flat_i = (1 - t) * tile_flat_p0[itile] + t * tile_flat_p1[itile]
+                            data_f[li] = (data_f[li] - dark_mean) / (flat_i - dark_mean+ 1e-3)
+                    else:
+                        data_f = (data_f - dark_mean) / (tile_flat[itile] - dark_mean+ 1e-3)
+                    np.nan_to_num(data_f, nan=1.0, posinf=1.0, neginf=1.0, copy=False)
+                    if args.zinger_level > 0:
+                        from scipy.ndimage import median_filter
+                        kernel = (min(5, data_f.shape[0]), 1, 1)
+                        med = median_filter(data_f, size=kernel)
+                        mask = data_f > med * (1 + args.zinger_level)
+                        data_f[mask] = med[mask]
+                    # intensity scale calibration using overlap with previous tile (per projection)
+                    if itile > 0 and ref_overlap_mean is not None:
+                        overlap_cols = data_shape[2] - x_shifts[itile]
+                        cur_means = np.mean(data_f[:, :, :overlap_cols], axis=(1, 2))  # (n_proj,)
+                        ref = ref_overlap_mean[proj_ids - st_chunk]
+                        valid = cur_means > 1e-6
+                        scales = np.where(valid, ref / np.where(valid, cur_means, 1.0), 1.0)
+                        data_f *= scales[:, np.newaxis, np.newaxis]
+                    if itile < grid.shape[1] - 1:
+                        ref_overlap_mean = np.zeros(chunk_len, dtype='float64')
+                        ref_overlap_mean[proj_ids - st_chunk] = np.mean(
+                            data_f[:, :, x_shifts[itile + 1]:], axis=(1, 2))
+
+                    chunk_buf[proj_ids - st_chunk, :, st:end] += data_f[:, :, :end - st] * vv[:end - st]
+                if itile == grid.shape[1] - 1:
+                    chunk_buf[:, :, end:] = np.tile(chunk_buf[:, :, end - 1:end], (1, 1, size - end))
+
+            np.nan_to_num(chunk_buf, nan=1.0, posinf=1.0, neginf=1.0, copy=False)
+            return st_chunk, end_chunk, chunk_buf
+
+        n_chunks = int(np.ceil((args.end_proj - args.start_proj) / args.nproj_per_chunk))
+        pending = {}
+        next_write = args.start_proj
+        with ThreadPoolExecutor(max_workers=args.max_workers) as pool:
+            futures = {pool.submit(process_chunk, i): i for i in range(n_chunks)}
+            for fut in as_completed(futures):
+                st_chunk, end_chunk, chunk_buf = fut.result()
+                pending[st_chunk] = (end_chunk, chunk_buf)
+                while next_write in pending:
+                    ep, buf = pending.pop(next_write)
+                    data_all[next_write - args.start_proj:ep - args.start_proj] = buf
+                    next_write = ep
             
     log.info(f'Output file {tile_file_name}')
     log.info(f'Reconstruct {tile_file_name} with tomocupy:')


### PR DESCRIPTION
## Summary

This PR brings in a series of bug fixes found while processing a real 4×3 mosaic dataset at APS 2-BM, followed by a set of new features that complete the end-to-end mosaic pipeline.

### Bug fixes

- **`tile_index_x_max` bug** (`tile/fileio.py`): the grid was sized using the last value of `tile_index_x` after the loop rather than the maximum seen during it. When the last file processed started a new row, `tile_index_x` reset to 1, producing an undersized grid and an `IndexError` on placement.
- **`NameError` in `center()`** (`tile/shift.py`): `rotation_axis` referenced before assignment; corrected to `args.rotation_axis`.
- **`--nsino-per-chunk` mismatch** (`tile/shift.py`): the value was hardcoded to `2` but `tmp.h5` contains `2**binning` sinogram rows. With `--binning 2` this gave `nz = 2 // 4 = 0`, causing a zero-shape array assignment crash in tomocupy.
- **cuFFT-unfriendly stitched width** (`tile/shift.py`): added `_next_smooth()` helper that rounds the stitched image width up to the nearest integer whose prime factors are all in {2, 3, 5}, preventing CUDA FFT segfaults on prime-containing widths.
- **`--file-type double_fov` hardcoded** (`tile/shift.py`): `tile center` and `tile shift` always appended `--file-type double_fov` to the tomocupy call, making it impossible to process non-double-FOV datasets. Made configurable via `--file-type` (default: `double_fov` to preserve existing behaviour at 2-BM).

### New features (merged from Viktor Nikitin's work on the 2-BM dataset)

- **`tile panoramic`**: stitches a single projection from all tiles and saves it as a TIFF for quick visual verification of tile layout and nominal overlap.
- **Per-tile flat/dark correction** in `tile center` and `tile stitch`: flat and dark arrays are pre-computed per tile and applied before stitching, rather than after. Supports three modes:
  - simple average (`--flat-linear False`)
  - linear interpolation between first-half and second-half flat means (`--flat-linear True`, recommended)
  - per-projection NNLS combination of an external flat basis (`--flats-file`)
- **Zinger removal** in `tile stitch` (`--zinger-level`): temporal median filter to suppress bright outlier pixels.
- **Intensity scale calibration** between adjacent tiles in `tile stitch`: per-projection mean in the overlap region is used to normalise brightness differences between tiles.
- **`--x-shifts` moved to `file-io` section** so it is available in both `tile center` and `tile stitch`.
- **`--nsino-per-chunk` moved to `center` section**; `--max-workers` added to `stitch` section.
- **Default updates for 2-BM**: `--recon-engine` → `tomocupy`, `--reverse-grid` → `True`, `--file-type` → `double_fov`.
- **`bin/vstitch`**: standalone script for vertical stitching of per-row `tile.h5` files.
- **`log.action()`**: new red-coloured log level for operator prompts.

### New pipeline commands (`tile/prep.py`)

Four new subcommands that complete the full mosaic pipeline:

| Command | What it does |
|---|---|
| `tile bin` | Spatially bin raw HDF5 files (`2**N × 2**N`) with optional projection subsampling (`--bin-step`) |
| `tile dump-flats` | Collect averaged flat field basis from all tile files for NNLS flat correction |
| `tile vstitch` | Vertically stitch per-row `tile.h5` files with quintic blending and intensity calibration |
| `tile double-fov` | Convert 360° acquisition to 180° by stitching `projection[i]` with `fliplr(projection[i + N/2])` |

The full pipeline is now:

```
tile show → tile bin → tile dump-flats → tile panoramic →
tile center → tile shift → tile stitch → tile vstitch → tile double-fov → tomocupy recon
```

### Documentation

`docs/source/usage.rst` has been completely rewritten with:
- A 10-step pipeline overview table
- Per-command parameter reference with notes and warnings
- A full worked example for a 4-row × 3-column 360° mosaic dataset

## Test plan

- [ ] `tile show` on a multi-tile dataset prints correct grid layout
- [ ] `tile bin` produces correctly sized output files with expected shape
- [ ] `tile dump-flats` collects the right number of frames from each input file
- [ ] `tile panoramic` saves a TIFF without error
- [ ] `tile center` completes without crash for both `--file-type double_fov` and `--file-type standard`
- [ ] `tile shift` completes the interactive shift search for all tile boundaries
- [ ] `tile stitch` produces a valid `tile.h5` with `data_white=1`, `data_dark=0`
- [ ] `tile vstitch` correctly blends multiple `tile.h5` rows into a single file
- [ ] `tile double-fov` produces an N/2-projection output with the correct width

